### PR TITLE
Potential fix for code scanning alert no. 79: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,6 +7,9 @@ on:
         description: "Already created tag"
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   buildx:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ on:
     tags:
       - v*
 
+permissions:
+  contents: write
+  actions: write
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
Potential fix for [https://github.com/devld/go-drive/security/code-scanning/79](https://github.com/devld/go-drive/security/code-scanning/79)

Add an explicit `permissions` block to the workflow (or this job) with least privileges needed by the existing steps.  
Best single fix here: define workflow-level permissions right after `on:` (before `jobs:`) so all jobs inherit it consistently.

For this workflow:
- `contents: write` is needed for creating GitHub releases and uploading release assets.
- `actions/cache` may require `actions: write` for cache save/restore in many setups.
- No other write scopes are indicated by the shown steps.

So update `.github/workflows/release.yml` by inserting:

```yml
permissions:
  contents: write
  actions: write
```

between the trigger section and `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only tightens/declares GitHub Actions token permissions for existing workflows, which may require minor adjustment if any step implicitly needed additional scopes.
> 
> **Overview**
> Adds explicit workflow-level `permissions` blocks to address code-scanning guidance.
> 
> `docker-image.yml` now declares `contents: read`, and `release.yml` declares `contents: write` plus `actions: write` so jobs run with explicitly scoped `GITHUB_TOKEN` access.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4f1e326c8a7aee9b5adf619a578b22c1bf04299. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->