### PR TITLE
Fix WebDAV permission status handling

### DIFF
--- a/server/webdav/webdav.go
+++ b/server/webdav/webdav.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -70,6 +71,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if errors.Is(err, os.ErrPermission) {
+		status = http.StatusForbidden
+	}
 	if status != 0 {
 		w.WriteHeader(status)
 		if status != http.StatusNoContent {
@@ -284,6 +288,9 @@ func (h *Handler) handlePut(w http.ResponseWriter, r *http.Request) (status int,
 
 	f, err := h.FileSystem.OpenFile(ctx, reqPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return http.StatusConflict, err
+		}
 		return http.StatusNotFound, err
 	}
 	_, copyErr := io.Copy(f, r.Body)
@@ -554,13 +561,13 @@ func (h *Handler) handlePropfind(w http.ResponseWriter, r *http.Request) (status
 
 	walkFn := func(reqPath string, info os.FileInfo, err error) error {
 		if err != nil {
-			return err
+			return handlePropfindError(err, info)
 		}
 		var pstats []Propstat
 		if pf.Propname != nil {
 			pnames, err := propnames(ctx, h.FileSystem, h.LockSystem, info, reqPath)
 			if err != nil {
-				return err
+				return handlePropfindError(err, info)
 			}
 			pstat := Propstat{Status: http.StatusOK}
 			for _, xmlname := range pnames {
@@ -573,7 +580,7 @@ func (h *Handler) handlePropfind(w http.ResponseWriter, r *http.Request) (status
 			pstats, err = props(ctx, h.FileSystem, h.LockSystem, info, reqPath, pf.Prop)
 		}
 		if err != nil {
-			return err
+			return handlePropfindError(err, info)
 		}
 		href := path.Join(h.Prefix, reqPath)
 		if href != "/" && info.IsDir() {
@@ -650,6 +657,24 @@ func makePropstatResponse(href string, pstats []Propstat) *response {
 		})
 	}
 	return &resp
+}
+
+// handlePropfindError mirrors the upstream x/net/webdav behavior: resources
+// that cannot be represented as valid WebDAV resources are omitted while a
+// directory that cannot be traversed is pruned from the walk.
+func handlePropfindError(err error, info os.FileInfo) error {
+	var skipResp error
+	if info != nil && info.IsDir() {
+		skipResp = filepath.SkipDir
+	}
+
+	if errors.Is(err, os.ErrPermission) {
+		return skipResp
+	}
+	if _, ok := err.(*os.PathError); ok {
+		return skipResp
+	}
+	return err
 }
 
 const (

--- a/server/webdav/webdav_test.go
+++ b/server/webdav/webdav_test.go
@@ -241,6 +241,69 @@ func TestEscapeXML(t *testing.T) {
 	}
 }
 
+type permissionFileSystem struct{}
+
+func (permissionFileSystem) Mkdir(context.Context, string, os.FileMode) error {
+	return os.ErrPermission
+}
+
+func (permissionFileSystem) OpenFile(context.Context, string, int, os.FileMode) (File, error) {
+	return nil, os.ErrPermission
+}
+
+func (permissionFileSystem) RemoveAll(context.Context, string) error {
+	return os.ErrPermission
+}
+
+func (permissionFileSystem) Rename(context.Context, string, string) error {
+	return os.ErrPermission
+}
+
+func (permissionFileSystem) Stat(context.Context, string) (os.FileInfo, error) {
+	return nil, os.ErrPermission
+}
+
+func TestPermissionErrorReturnsForbidden(t *testing.T) {
+	tests := []struct {
+		method      string
+		destination bool
+	}{
+		{method: "GET"},
+		{method: "DELETE"},
+		{method: "PUT"},
+		{method: "MKCOL"},
+		{method: "COPY", destination: true},
+		{method: "MOVE", destination: true},
+		{method: "PROPFIND"},
+		{method: "PROPPATCH"},
+	}
+
+	h := &Handler{FileSystem: permissionFileSystem{}, LockSystem: NewMemLS()}
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, "http://example.com/file", nil)
+			if tt.destination {
+				req.Header.Set("Destination", "http://example.com/destination")
+			}
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+			if got := w.Code; got != http.StatusForbidden {
+				t.Fatalf("status = %d, want %d", got, http.StatusForbidden)
+			}
+		})
+	}
+}
+
+func TestPutWithoutParentReturnsConflict(t *testing.T) {
+	h := &Handler{FileSystem: NewMemFS(), LockSystem: NewMemLS()}
+	req := httptest.NewRequest("PUT", "http://example.com/missing/file", strings.NewReader("data"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if got := w.Code; got != http.StatusConflict {
+		t.Fatalf("status = %d, want %d", got, http.StatusConflict)
+	}
+}
+
 func TestFilenameEscape(t *testing.T) {
 	hrefRe := regexp.MustCompile(`<D:href>([^<]*)</D:href>`)
 	displayNameRe := regexp.MustCompile(`<D:displayname>([^<]*)</D:displayname>`)


### PR DESCRIPTION
## What changed

- map filesystem permission errors to HTTP 403 instead of 405
- port upstream WebDAV handling for permission/path errors during PROPFIND traversal
- return HTTP 409 when PUT targets a resource whose parent collection is missing
- add regression coverage across core WebDAV methods

## Why

`os.ErrPermission` indicates authorization failure, while 405 means the HTTP method itself is unsupported for the resource. Returning 403 preserves the actual failure semantics.

## Validation

- `go test ./server/webdav`
- live WebDAV verification under `/dav/files` for protected-path 403 responses
- authenticated MKCOL, PUT, GET, PROPFIND, COPY, MOVE, DELETE, OPTIONS, and HEAD checks