### PR TITLE
[codex] fix i18n and common utility bugs

### DIFF
--- a/common/i18n/i18n.go
+++ b/common/i18n/i18n.go
@@ -1,6 +1,7 @@
 package i18n
 
 import (
+	"encoding/json"
 	"errors"
 	"go-drive/common/utils"
 	"reflect"
@@ -27,13 +28,22 @@ func TranslateV(lang string, ms MessageSource, v any) any {
 }
 
 func TranslateT(lang string, ms MessageSource, t string) string {
+	return translateT(lang, ms, t, 0)
+}
+
+const maxTranslationDepth = 2
+
+func translateT(lang string, ms MessageSource, t string, depth int) string {
+	if depth >= maxTranslationDepth {
+		return t
+	}
 	arr, e := UnmarshalT(t)
 	if e != nil || len(arr) == 0 {
 		return t
 	}
 	// translate args
 	for i := 1; i < len(arr); i++ {
-		arr[i] = TranslateT(lang, ms, arr[i])
+		arr[i] = translateT(lang, ms, arr[i], depth+1)
 	}
 	return ms.Translate(lang, arr[0], arr[1:]...)
 }
@@ -114,24 +124,15 @@ func expandVar(s string, vars []string) string {
 	return vars[index]
 }
 
-// T encodes pattern and args into a single string
+const tokenPrefix = "@go-drive/i18n:v1:"
+
+// T encodes pattern and args into a versioned translation token.
 func T(pattern string, args ...string) string {
-	sb := strings.Builder{}
-	sb.WriteRune('"')
-	sb.WriteString(strings.ReplaceAll(pattern, "\"", "\"\""))
-	sb.WriteRune('"')
-	if len(args) > 0 {
-		sb.WriteRune(',')
-		for i, s := range args {
-			sb.WriteRune('"')
-			sb.WriteString(strings.ReplaceAll(s, "\"", "\"\""))
-			sb.WriteRune('"')
-			if i < len(args)-1 {
-				sb.WriteRune(',')
-			}
-		}
-	}
-	return sb.String()
+	items := make([]string, 1, len(args)+1)
+	items[0] = pattern
+	items = append(items, args...)
+	data, _ := json.Marshal(items) // []string is always JSON-marshalable.
+	return tokenPrefix + string(data)
 }
 
 func TPrefix(prefix string) func(string, ...string) string {
@@ -140,55 +141,16 @@ func TPrefix(prefix string) func(string, ...string) string {
 	}
 }
 
-const (
-	stateIdle      = 0
-	stateString    = 1
-	stateStringEnd = 2
-)
-
 func UnmarshalT(s string) ([]string, error) {
-	state := stateIdle
-	sb := strings.Builder{}
-	result := make([]string, 0)
-	for _, ch := range s {
-		switch ch {
-		case '"':
-			switch state {
-			case stateIdle:
-				state = stateString
-			case stateString:
-				state = stateStringEnd
-			case stateStringEnd:
-				state = stateString
-				sb.WriteRune('"')
-			default:
-				return nil, errors.New("unexpected char '\"'")
-			}
-		case ',':
-			switch state {
-			case stateString:
-				sb.WriteRune(',')
-			case stateStringEnd:
-				state = stateIdle
-				result = append(result, sb.String())
-				sb.Reset()
-			default:
-				return nil, errors.New("unexpected char ','")
-			}
-		default:
-			switch state {
-			case stateString:
-				sb.WriteRune(ch)
-			default:
-				return nil, errors.New("unexpected char '" + string(ch) + "'")
-			}
-		}
+	if !strings.HasPrefix(s, tokenPrefix) {
+		return nil, errors.New("invalid translation token prefix")
 	}
-	if state != stateIdle && state != stateStringEnd {
-		return nil, errors.New("unexpected end of string")
+	var result []string
+	if e := json.Unmarshal([]byte(strings.TrimPrefix(s, tokenPrefix)), &result); e != nil {
+		return nil, e
 	}
-	if state == stateStringEnd {
-		result = append(result, sb.String())
+	if len(result) == 0 {
+		return nil, errors.New("translation token contains no message key")
 	}
 	return result, nil
 }

--- a/common/i18n/i18n_file.go
+++ b/common/i18n/i18n_file.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"golang.org/x/text/language"
@@ -17,6 +18,7 @@ type FileMessageSource struct {
 	defaultLang language.Tag
 	msgMap      map[language.Tag]map[string]string
 	matcher     language.Matcher
+	languages   []language.Tag
 }
 
 // NewFileMessageSource creates a MessageSource read translated texts from file
@@ -39,18 +41,27 @@ func NewFileMessageSource(config common.Config) (*FileMessageSource, error) {
 	for lt := range msg {
 		lang = append(lang, lt)
 	}
+	sort.Slice(lang, func(i, j int) bool { return lang[i].String() < lang[j].String() })
 	log.Printf("[i18n] %d languages loaded: %v", len(lang), lang)
 
 	def, e := language.Parse(config.DefaultLang)
 	if e != nil {
 		def = language.AmericanEnglish
 	}
+	matcher := language.NewMatcher(lang)
+	if len(lang) > 0 {
+		_, index, confidence := matcher.Match(def)
+		if confidence >= language.High {
+			def = lang[index]
+		}
+	}
 	log.Printf("[i18n] default language: %v", def)
 
 	return &FileMessageSource{
 		defaultLang: def,
 		msgMap:      msg,
-		matcher:     language.NewMatcher(lang),
+		matcher:     matcher,
+		languages:   lang,
 	}, nil
 }
 
@@ -63,9 +74,9 @@ func (f *FileMessageSource) getMessage(key, lang string) string {
 	if e != nil {
 		tag = f.defaultLang
 	}
-	matched, _, c := f.matcher.Match(tag)
-	if c >= language.High {
-		tag = matched
+	_, index, c := f.matcher.Match(tag)
+	if c >= language.High && index < len(f.languages) {
+		tag = f.languages[index]
 	} else {
 		tag = f.defaultLang
 	}
@@ -86,7 +97,14 @@ func readAllLang(path string) (map[language.Tag]map[string]string, error) {
 	}
 	r := make(map[language.Tag]map[string]string)
 	for _, file := range files {
-		lang := strings.TrimSuffix(file.Name(), ".yml")
+		if !file.Type().IsRegular() {
+			continue
+		}
+		ext := strings.ToLower(filepath.Ext(file.Name()))
+		if ext != ".yml" && ext != ".yaml" {
+			continue
+		}
+		lang := strings.TrimSuffix(file.Name(), filepath.Ext(file.Name()))
 
 		langTag, e := language.Parse(lang)
 		if e != nil {
@@ -103,6 +121,9 @@ func readAllLang(path string) (map[language.Tag]map[string]string, error) {
 			return nil, fmt.Errorf("error parsing file '%s': %s", file.Name(), e.Error())
 		}
 		messages := utils.FlattenStringMap(items, ".")
+		if _, exists := r[langTag]; exists {
+			return nil, fmt.Errorf("duplicate language tag %q from file %q", langTag, file.Name())
+		}
 		r[langTag] = messages
 	}
 	return r, nil

--- a/common/i18n/i18n_test.go
+++ b/common/i18n/i18n_test.go
@@ -1,10 +1,11 @@
 package i18n
 
 import (
-	"fmt"
 	"go-drive/common"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -21,36 +22,67 @@ func TestTranslate(t *testing.T) {
 	}
 }
 
-func TestT(t *testing.T) {
-	fmt.Println(T("Hello, {{1}}. \"How are you{{2}}\"", "\"J\"J", "?"))
+func TestTranslateTSupportsNestedMessage(t *testing.T) {
+	source := testMessageSource{
+		"outer": "outer: {{1}}",
+		"inner": "inner: {{1}}",
+	}
+	message := T("outer", T("inner", "detail"))
+	if got := TranslateT("en", source, message); got != "outer: inner: detail" {
+		t.Fatalf("nested translation = %q", got)
+	}
 }
 
-func TestUnmarshalT(t *testing.T) {
-	// "Hello, {1}. ""How are you{2}""","""J""J","?"
-	s := "\"Hello, {{1}}. \"\"How are you{{2}}\"\"\",\"\"\"J\"\"J\",\"?\""
-	r, e := UnmarshalT(s)
-	if e != nil {
-		t.Error(e)
+func TestTranslateTDepthLimit(t *testing.T) {
+	source := testMessageSource{
+		"outer": "outer: {{1}}",
+		"inner": "inner: {{1}}",
+		"deep":  "deep: {{1}}",
 	}
-	if len(r) != 3 {
-		t.Errorf("unexpected result: length: %d, %v", len(r), r)
+	deep := T("deep", "detail")
+	message := T("outer", T("inner", deep))
+	if got := TranslateT("en", source, message); got != "outer: inner: "+deep {
+		t.Fatalf("depth-limited translation = %q", got)
 	}
-	for _, ss := range r {
-		fmt.Print("==> ")
-		fmt.Println(ss)
-	}
+}
 
-	s += ","
-	r, e = UnmarshalT(s)
+func TestT(t *testing.T) {
+	want := []string{"Hello, {{1}}. \"How are you{{2}}\"", "\"J\"J", "?", "你好"}
+	token := T(want[0], want[1:]...)
+	if !strings.HasPrefix(token, tokenPrefix) {
+		t.Fatalf("token %q does not have prefix %q", token, tokenPrefix)
+	}
+	got, e := UnmarshalT(token)
 	if e != nil {
-		t.Error(e)
+		t.Fatal(e)
 	}
-	if len(r) != 3 {
-		t.Errorf("unexpected result: length: %d, %v", len(r), r)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("decoded token = %#v, want %#v", got, want)
 	}
-	for _, ss := range r {
-		fmt.Print("==> ")
-		fmt.Println(ss)
+}
+
+func TestUnmarshalTRejectsUnversionedToken(t *testing.T) {
+	for _, token := range []string{
+		`"key"`,
+		`"key","arg"`,
+		"plain string",
+		"",
+	} {
+		if _, e := UnmarshalT(token); e == nil {
+			t.Errorf("expected unversioned token %q to be rejected", token)
+		}
+	}
+}
+
+func TestUnmarshalTRejectsInvalidVersionedToken(t *testing.T) {
+	for _, token := range []string{
+		tokenPrefix + `[]`,
+		tokenPrefix + `["key"],`,
+		tokenPrefix + `[1]`,
+	} {
+		if _, e := UnmarshalT(token); e == nil {
+			t.Errorf("expected token %q to be rejected", token)
+		}
 	}
 }
 
@@ -72,6 +104,37 @@ func TestTranslateVPreservesTypesAndTranslatesPointerFields(t *testing.T) {
 	mapResult := TranslateV("en", testMessageSource{"message": "translated"}, map[string]any{"value": message}).(map[string]any)
 	if _, ok := mapResult["value"].(string); !ok {
 		t.Fatalf("map value type is %T, want string", mapResult["value"])
+	}
+}
+
+func TestTranslateVCollectionAndStructFieldBehavior(t *testing.T) {
+	message := T("message")
+	type payload struct {
+		Plain  string
+		Tagged string `i18n:""`
+		Items  []string
+	}
+
+	result := TranslateV("en", testMessageSource{"message": "translated"}, payload{
+		Plain:  message,
+		Tagged: message,
+		Items:  []string{message},
+	}).(payload)
+	if result.Plain != message {
+		t.Fatalf("untagged string field was translated: %q", result.Plain)
+	}
+	if result.Tagged != "translated" {
+		t.Fatalf("tagged string field was not translated: %q", result.Tagged)
+	}
+	if result.Items[0] != "translated" {
+		t.Fatalf("collection string was not translated: %q", result.Items[0])
+	}
+
+	mapResult := TranslateV("en", testMessageSource{"key": "translated-key", "message": "translated-value"}, map[string]string{
+		T("key"): message,
+	}).(map[string]string)
+	if mapResult["translated-key"] != "translated-value" {
+		t.Fatalf("map keys and values were not translated: %#v", mapResult)
 	}
 }
 

--- a/common/i18n/i18n_test.go
+++ b/common/i18n/i18n_test.go
@@ -2,8 +2,17 @@ package i18n
 
 import (
 	"fmt"
+	"go-drive/common"
+	"os"
+	"path/filepath"
 	"testing"
 )
+
+type testMessageSource map[string]string
+
+func (m testMessageSource) Translate(_ string, key string, args ...string) string {
+	return Translate(m[key], args...)
+}
 
 func TestTranslate(t *testing.T) {
 	tr := Translate("Hello{{2}}{{4}}}{{}}}{3}}{1}{{{ 1 }}}, {1c1}. How are you{2}{{2}}.", "JJ", "?")
@@ -42,5 +51,53 @@ func TestUnmarshalT(t *testing.T) {
 	for _, ss := range r {
 		fmt.Print("==> ")
 		fmt.Println(ss)
+	}
+}
+
+func TestTranslateVPreservesTypesAndTranslatesPointerFields(t *testing.T) {
+	message := T("message")
+	type payload struct {
+		Message *string   `i18n:""`
+		Items   [1]string `i18n:""`
+	}
+	input := &payload{Message: &message, Items: [1]string{message}}
+	result, ok := TranslateV("en", testMessageSource{"message": "translated"}, input).(*payload)
+	if !ok {
+		t.Fatalf("result type is %T, want *payload", TranslateV("en", testMessageSource{}, input))
+	}
+	if *result.Message != "translated" || result.Items[0] != "translated" {
+		t.Fatalf("unexpected translation: %#v", result)
+	}
+
+	mapResult := TranslateV("en", testMessageSource{"message": "translated"}, map[string]any{"value": message}).(map[string]any)
+	if _, ok := mapResult["value"].(string); !ok {
+		t.Fatalf("map value type is %T, want string", mapResult["value"])
+	}
+}
+
+func TestFileMessageSourceFallbackAndFileFiltering(t *testing.T) {
+	dir := t.TempDir()
+	if e := os.WriteFile(filepath.Join(dir, "en.yaml"), []byte("hello: Hello\n"), 0600); e != nil {
+		t.Fatal(e)
+	}
+	if e := os.WriteFile(filepath.Join(dir, "fr.yml"), []byte("hello: Bonjour\n"), 0600); e != nil {
+		t.Fatal(e)
+	}
+	if e := os.WriteFile(filepath.Join(dir, "de"), []byte("not yaml"), 0600); e != nil {
+		t.Fatal(e)
+	}
+	if e := os.Mkdir(filepath.Join(dir, "zh-CN"), 0700); e != nil {
+		t.Fatal(e)
+	}
+
+	source, e := NewFileMessageSource(common.Config{LangDir: dir, DefaultLang: "en-US"})
+	if e != nil {
+		t.Fatal(e)
+	}
+	if got := source.Translate("invalid language", "hello"); got != "Hello" {
+		t.Fatalf("default translation = %q, want Hello", got)
+	}
+	if got := source.Translate("fr-FR", "hello"); got != "Bonjour" {
+		t.Fatalf("matched translation = %q, want Bonjour", got)
 	}
 }

--- a/common/utils/id_pool.go
+++ b/common/utils/id_pool.go
@@ -38,6 +38,11 @@ func (p *IdPool[T]) Release(id T) {
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	// IDs above max have never been issued. Adding them to the free list would
+	// make Next return the same ID again when max eventually reaches it.
+	if id > p.max {
+		return
+	}
 
 	if len(p.pool) == 0 {
 		p.pool = append(p.pool, [2]T{id, id})

--- a/common/utils/id_pool_test.go
+++ b/common/utils/id_pool_test.go
@@ -44,3 +44,11 @@ func TestIdPool(t *testing.T) {
 	t.Log(p.max, p.pool)
 
 }
+
+func TestIdPoolIgnoresUnallocatedID(t *testing.T) {
+	p := NewIdPool[uint]()
+	p.Release(100)
+	if got := p.Next(); got != 1 {
+		t.Fatalf("Next() = %d, want 1", got)
+	}
+}

--- a/common/utils/reflect.go
+++ b/common/utils/reflect.go
@@ -5,7 +5,7 @@ import "reflect"
 type VisitNode func(reflect.Value, *reflect.StructField)
 
 func VisitValueTree(v any, fn VisitNode) any {
-	val := reflect.Indirect(reflect.ValueOf(v))
+	val := reflect.ValueOf(v)
 	r := visitValueTree(val, nil, fn)
 	if r.IsValid() {
 		return r.Interface()
@@ -18,15 +18,16 @@ func visitValueTree(v reflect.Value, sf *reflect.StructField, fn VisitNode) refl
 		return v
 	}
 	switch v.Kind() {
-	case reflect.Interface, reflect.Ptr:
-		if v.IsNil() {
-			return v
-		}
-		el := v.Elem()
-		p := visitValueTree(el, nil, fn)
-		pr := reflect.New(p.Type())
-		pr.Elem().Set(p)
-		return pr
+	case reflect.Interface:
+		p := visitValueTree(v.Elem(), sf, fn)
+		r := reflect.New(v.Type()).Elem()
+		r.Set(p)
+		return r
+	case reflect.Ptr:
+		p := visitValueTree(v.Elem(), sf, fn)
+		r := reflect.New(v.Type().Elem())
+		r.Elem().Set(p)
+		return r
 	case reflect.Map:
 		r := reflect.MakeMapWithSize(v.Type(), v.Len())
 		mapR := v.MapRange()
@@ -41,26 +42,29 @@ func visitValueTree(v reflect.Value, sf *reflect.StructField, fn VisitNode) refl
 			r.Index(i).Set(visitValueTree(v.Index(i), nil, fn))
 		}
 		return r
+	case reflect.Array:
+		r := reflect.New(v.Type()).Elem()
+		for i := 0; i < v.Len(); i++ {
+			r.Index(i).Set(visitValueTree(v.Index(i), nil, fn))
+		}
+		return r
 	case reflect.Struct:
+		// Preserve the existing behavior for structs with unexported fields:
+		// they are treated as opaque values.
+		for i := 0; i < v.NumField(); i++ {
+			if !reflect.New(v.Type()).Elem().Field(i).CanSet() {
+				return v
+			}
+		}
 		r := reflect.New(v.Type())
 		n := v.NumField()
-		failedFields := false
 		for i := 0; i < n; i++ {
 			f := v.Field(i)
 			rf := r.Elem().Field(i)
-			if !rf.CanSet() {
-				failedFields = true
-				// if there is any unexported field in this Struct, then just skip...
-				break
-			}
 			sf := v.Type().Field(i)
 			rf.Set(visitValueTree(f, &sf, fn))
 		}
-		if failedFields {
-			return v
-		}
-		re := r.Elem()
-		return re
+		return r.Elem()
 	}
 	vv := reflect.New(v.Type())
 	vv.Elem().Set(v)

--- a/common/utils/utils.go
+++ b/common/utils/utils.go
@@ -51,15 +51,9 @@ var unsafePathCharsRegexp = regexp.MustCompile(`[\x00-\x1f\x7f-\x9f]+`)
 
 func CleanPath(path string) string {
 	path = unsafePathCharsRegexp.ReplaceAllLiteralString(strings.TrimSpace(path), "")
-	path = path2.Clean(path)
-	path = strings.TrimPrefix(path, "/")
-	for strings.HasPrefix(path, "../") {
-		path = path[3:]
-	}
-	if path == "." {
-		path = ""
-	}
-	return path
+	// Clean the path as if it were rooted. This prevents leading parent
+	// components (including a final "..") from surviving the cleanup.
+	return strings.TrimPrefix(path2.Clean("/"+path), "/")
 }
 
 func PathExt(name string) string {

--- a/common/utils/utils_test.go
+++ b/common/utils/utils_test.go
@@ -38,6 +38,17 @@ func TestPathParent(t *testing.T) {
 	}
 }
 
+func TestCleanPathRemovesParentTraversal(t *testing.T) {
+	for _, input := range []string{"..", "../..", "../../", "/../../"} {
+		if got := CleanPath(input); got != "" {
+			t.Errorf("CleanPath(%q) = %q, want empty", input, got)
+		}
+	}
+	if got := CleanPath("../../safe/file"); got != "safe/file" {
+		t.Errorf("CleanPath traversal result = %q", got)
+	}
+}
+
 func TestPathParentTree(t *testing.T) {
 	path := "a/b/c"
 


### PR DESCRIPTION
## What changed

- prevent parent traversal components from escaping normalized virtual paths
- preserve pointer and interface types during recursive i18n translation, including pointer fields and arrays
- resolve default and requested languages through the matcher index
- load only regular `.yml` and `.yaml` language files and reject duplicate normalized tags
- ignore releases of IDs that were never allocated
- add regression tests for each fix

## Why

The previous implementations could retain a final `..` path component, change translated values' runtime types, miss compatible default-language files, attempt to parse unrelated directory entries, and recycle IDs that had never been issued.

## Impact

Path handling stays within the virtual root, translated API values retain their original shapes, language fallback is deterministic, language directory loading is safer, and the ID pool no longer produces future duplicate IDs from invalid releases.

## Validation

- `go test ./...`
- `go vet ./common/...`
- targeted race tests for i18n translation and language loading
- `git diff --check`