### PR TITLE
feat(i18n): add Korean (ko) translation

### DIFF
--- a/docs/lang/ko-KR.yml
+++ b/docs/lang/ko-KR.yml
@@ -1,0 +1,307 @@
+error:
+  not_found: 찾을 수 없습니다
+  not_allowed: 허용되지 않는 작업입니다
+  permission_denied: 리소스를 찾을 수 없거나 권한이 없습니다
+  fail_ban_message: 실패 횟수가 너무 많습니다. 잠시 후 다시 시도해 주세요
+util:
+  request_failed: "[{{ 1 }}] 요청이 실패했습니다"
+oauth:
+  state_mismatch: state 값이 일치하지 않습니다
+search:
+  invalid_query: 잘못된 검색어입니다
+api:
+  admin:
+    unknown_drive_type: 알 수 없는 드라이브 유형 '{{ 1 }}'
+    invalid_drive_name: 잘못된 드라이브 이름 '{{ 1 }}'
+    invalid_file_bucket_name: 잘못된 이름 '{{ 1 }}'
+  auth:
+    invalid_username_or_password: 아이디 또는 비밀번호가 올바르지 않습니다
+    provider_not_found: 인증 제공자 '{{ 1 }}'를 찾을 수 없습니다
+    start_not_supported: 인증 제공자 '{{ 1 }}'는 이 작업을 지원하지 않습니다
+    group_permission_required: 그룹 '{{ 1 }}'의 권한이 필요합니다
+    field_username: 아이디
+    field_password: 비밀번호
+  drive:
+    copy_to_same_path_not_allowed: 같은 경로로 복사하거나 이동할 수 없습니다
+    copy_to_child_path_not_allowed: 하위 경로로 복사하거나 이동할 수 없습니다
+    invalid_file_size: 잘못된 파일 크기입니다
+    invalid_size_or_chunk_size: 잘못된 크기 또는 청크 크기입니다
+  chunk_uploader:
+    invalid_file_size: 잘못된 파일 크기입니다
+    invalid_chunk_seq: 잘못된 청크 순서입니다
+    chunk_size_cannot_less_than: 청크 크기는 {{ 1 }}보다 작을 수 없습니다
+    expected__bytes_but__bytes: "{{ 1 }} 바이트를 예상했지만 {{ 2 }} 바이트를 받았습니다"
+    missing_chunks: 누락된 청크가 있습니다
+    invalid_upload_id: 잘못된 업로드 ID입니다
+  db_token:
+    invalid_token: 잘못된 토큰입니다
+  permission_wrapper:
+    no_subfolder_permission: 하위 폴더에 대한 권한이 없습니다
+  thumbnail:
+    file_too_large: 파일 크기가 너무 커서 썸네일을 생성할 수 없습니다
+    image_too_large: 이미지가 너무 커서 썸네일을 생성할 수 없습니다
+    create_failed: 썸네일을 생성할 수 없습니다
+  zip:
+    size_exceed: 최대 허용 크기 {{ 1 }}를 초과했습니다
+storage:
+  drives:
+    drive_exists: 드라이브 '{{ 1 }}'가 이미 존재합니다
+  groups:
+    group_not_exists: 그룹 '{{ 1 }}'이(가) 존재하지 않습니다
+    group_exists: 그룹 '{{ 1 }}'이(가) 이미 존재합니다
+  users:
+    user_not_exists: 사용자 '{{ 1 }}'이(가) 존재하지 않습니다
+    user_exists: 사용자 '{{ 1 }}'이(가) 이미 존재합니다
+  file_bucket:
+    bucket_exists: 버킷 '{{ 1 }}'이(가) 이미 존재합니다
+drive:
+  not_configured: 드라이브가 설정되지 않았습니다
+  copy_type_mismatch1: 대상 '{{ 2 }}'은(는) 파일이지만, 원본 '{{ 1 }}'은(는) 폴더입니다
+  copy_type_mismatch2: 대상 '{{ 2 }}'은(는) 폴더이지만, 원본 '{{ 1 }}'은(는) 파일입니다
+  file_exists: 파일이 이미 존재합니다
+  file_not_exists: 파일이 존재하지 않습니다
+  invalid_path: 잘못된 경로입니다
+  file_not_downloadable: 이 파일은 다운로드할 수 없습니다
+  path_meta:
+    incorrect_password: 비밀번호가 올바르지 않습니다
+  root:
+    invalid_drive_type: 잘못된 드라이브 유형 '{{ 1 }}'
+    invalid_drive_config: 드라이브 '{{ 1 }}'의 설정이 잘못되었습니다
+    error_create_drive: "드라이브 '{{ 1 }}' 생성 중 오류 발생: {{ 2 }}"
+  dispatcher:
+    move_across_not_supported: 드라이브 간 이동은 지원되지 않습니다
+  gdrive:
+    name: Google Drive
+    readme: Google Drive, 참고 [Google Drive 설정하기](https://go-drive.top/drives/google-drive)
+    form:
+      client_id:
+        label: 클라이언트 ID
+        description: ""
+      client_secret:
+        label: 클라이언트 보안 비밀
+        description: ""
+      cache_ttl:
+        label: 캐시 TTL
+        description: "캐시 유지 시간이며, 생략하면 캐시를 사용하지 않습니다. 사용 가능한 시간 단위는 'ms', 's', 'm', 'h'입니다."
+      proxy_thumbnail:
+        label: 썸네일 프록시
+        description: 썸네일이 제대로 표시되지 않는 경우 이 옵션을 켜 보세요
+    oauth_text: Google Drive에 연결
+    drive_label: 드라이브
+    my_drive_name: 내 드라이브
+  onedrive:
+    name: OneDrive
+    readme: OneDrive, 참고 [OneDrive 설정하기](https://go-drive.top/drives/onedrive)
+    form:
+      site:
+        label: 계정 유형
+        description: ""
+        global: 글로벌
+        china: 중국
+      tenant:
+        label: 테넌트
+        description: ""
+        common: 개인 Microsoft 계정과 회사/학교 계정 모두 지원
+        organizations: 회사/학교 계정만 지원
+        consumers: 개인 Microsoft 계정만 지원
+      client_id:
+        label: 클라이언트 ID
+        description: ""
+      client_secret:
+        label: 클라이언트 보안 비밀
+        description: ""
+      share_point:
+        label: SharePoint URL
+        description: "SharePoint 사이트에 파일을 저장하려는 경우에만 입력하세요"
+      proxy_in:
+        label: 업로드 프록시
+        description: 서버 프록시를 통해 파일을 업로드합니다
+      proxy_out:
+        label: 다운로드 프록시
+        description: 서버 프록시를 통해 파일을 다운로드합니다
+      cache_ttl:
+        label: 캐시 TTL
+        description: "캐시 유지 시간이며, 생략하면 캐시를 사용하지 않습니다. 사용 가능한 시간 단위는 'ms', 's', 'm', 'h'입니다."
+    drive_not_selected: 드라이브가 아직 선택되지 않았거나 SharePoint 사이트 정보를 가져오지 못했습니다
+    oauth_text: OneDrive에 연결
+    drive_select: 드라이브 선택
+    drive_desc: "{{ 1 }} ({{ 2 }} / {{ 3 }} | {{ 4 }} 사용됨)"
+    unexpected_status: 예상치 못한 상태 코드 {{ 1 }}
+    unknown_action_status: "알 수 없는 작업 상태: {{ 1 }}"
+  fs:
+    name: 파일 시스템
+    readme: 로컬 파일 시스템 드라이브
+    form:
+      path:
+        label: 루트
+        description: 루트 경로
+    invalid_root_path: 잘못된 루트 경로입니다
+    root_path_not_exists: 루트 경로가 존재하지 않습니다
+    cannot_list_file: 파일에 대해서는 목록을 조회할 수 없습니다
+    cannot_delete_root: 루트는 삭제할 수 없습니다
+  s3:
+    name: S3
+    readme: S3 호환 스토리지
+    form:
+      ak:
+        label: AccessKey
+        description: ""
+      sk:
+        label: SecretKey
+        description: ""
+      bucket:
+        label: 버킷
+        description: ""
+      path_style:
+        label: PathStyle
+        description: path style API 사용을 강제합니다
+      region:
+        label: 리전
+        description: ""
+      endpoint:
+        label: 엔드포인트
+        description: S3 API 엔드포인트
+      proxy_in:
+        label: 업로드 프록시
+        description: 서버 프록시를 통해 파일을 업로드합니다
+      proxy_out:
+        label: 다운로드 프록시
+        description: 서버 프록시를 통해 파일을 다운로드합니다
+      cache_ttl:
+        label: 캐시 TTL
+        description: "캐시 유지 시간이며, 생략하면 캐시를 사용하지 않습니다. 사용 가능한 시간 단위는 'ms', 's', 'm', 'h'입니다."
+    bucket_not_exists: 버킷 '{{ 1 }}'을(를) 찾을 수 없습니다
+  webdav:
+    name: WebDAV
+    readme: WebDAV 프로토콜 드라이브
+    form:
+      url:
+        label: URL
+        description: 기본 URL
+      username:
+        label: 아이디
+        description: 아이디이며, 생략하면 인증이 필요하지 않습니다
+      password:
+        label: 비밀번호
+        description: ""
+      cache_ttl:
+        label: 캐시 TTL
+        description: "캐시 유지 시간이며, 생략하면 캐시를 사용하지 않습니다. 사용 가능한 시간 단위는 'ms', 's', 'm', 'h'입니다."
+    wrong_user_or_password: 아이디 또는 비밀번호가 올바르지 않을 수 있습니다
+    remote_error: "원격 서비스 오류: {{ 1 }}"
+  ftp:
+    name: FTP
+    readme: FTP 드라이브
+    form:
+      host:
+        label: 호스트
+        description: ""
+      port:
+        label: 포트
+        description: ""
+      user:
+        label: 사용자
+        description: 사용자 이름이며, 기본값은 'anonymous'입니다
+      password:
+        label: 비밀번호
+        description: 필요한 경우 사용자 비밀번호이며, 기본값은 'anonymous'입니다
+      concurrent:
+        label: 동시 연결 수
+        description: 최대 동시 FTP 연결 수이며, 기본값은 5입니다
+      timeout:
+        label: 타임아웃
+        description: "기본값은 5초이며, 사용 가능한 시간 단위는 'ms', 's', 'm', 'h'입니다"
+      cache_ttl:
+        label: 캐시 TTL
+        description: "캐시 유지 시간이며, 생략하면 캐시를 사용하지 않습니다. 사용 가능한 시간 단위는 'ms', 's', 'm', 'h'입니다."
+  sftp:
+    name: SFTP
+    readme: SFTP 드라이브 <br/> @[Vgbhfive](https://blog.vgbhfive.cn)
+    form:
+      host:
+        label: 호스트
+        description: ""
+      port:
+        label: 포트
+        description: "기본값은 22입니다"
+      user:
+        label: 사용자
+        description: 사용자 이름
+      password:
+        label: 비밀번호
+        description: 로그인 인증에 사용되는 비밀번호이며, 비밀번호와 개인 키 중 하나는 반드시 있어야 합니다
+      priv_key:
+        label: 개인 키
+        description: |
+          로그인 인증에 사용되는 개인 키입니다. 예: -----BEGIN RSA PRIVATE KEY-----. 현재 암호화된 개인 키는 지원되지 않으며, 개인 키와 비밀번호 중 하나는 반드시 있어야 합니다
+      host_key:
+        label: 호스트 키
+        description: 서버 신원 확인을 위한 호스트 키(선택 사항)
+      root_path:
+        label: 경로
+        description: "원격 서버의 루트 경로입니다. 기본값은 '/'입니다."
+      cache_ttl:
+        label: 캐시 TTL
+        description: "캐시 유지 시간이며, 생략하면 캐시를 사용하지 않습니다. 사용 가능한 시간 단위는 'ms', 's', 'm', 'h'입니다."
+    invalid_root_path: "루트 경로는 '/'로 시작해야 합니다"
+  script:
+    name: 스크립트
+    readme: JavaScript 드라이버를 사용합니다. 아래에서 저장하고 설정하세요
+    invalid_pool_config: "잘못된 Pool 설정: {{ 1 }}"
+    form:
+      pool:
+        label: Pool
+        description: "'MaxTotal,MaxIdle,MinIdle,IdleTime' 형식의 JavaScript 런타임 풀 설정이며, 기본값은 '100,50,10,30m'입니다. 자세한 내용은 https://pkg.go.dev/github.com/jolestar/go-commons-pool#ObjectPoolConfig 를 참고하세요"
+      script:
+        label: 스크립트 파일
+        description: scripts 폴더에 있는 스크립트를 선택하세요
+stat:
+  task:
+    total: 전체
+    pending: 대기 중
+    running: 실행 중
+    done: 완료
+    error: 오류
+    canceled: 취소됨
+jobs:
+  copy:
+    name: 복사
+    desc: 파일 복사
+    src: 원본 경로
+    src_desc: 복사할 원본 경로(한 줄에 하나씩), 와일드카드 지원
+    dest: 대상 경로
+    dest_desc: 반드시 존재하는 폴더여야 합니다
+    override: 덮어쓰기
+    override_desc: 복사 시 같은 이름의 파일을 덮어쓸지 여부이며, 그렇지 않으면 자동으로 이름이 변경됩니다
+    move: 이동
+    move_desc: 복사가 아닌 이동을 수행합니다
+  delete:
+    name: 삭제
+    desc: 파일 삭제
+    paths: 경로
+    paths_desc: 삭제할 경로(한 줄에 하나씩), 와일드카드 지원
+  flow:
+    name: 흐름
+    desc: 여러 작업을 순서대로 실행합니다
+    add_text: 작업 추가
+    ignore_err: 오류 무시
+    ignore_err_desc: 이 작업이 실패하면 오류를 무시하고 다음 작업을 계속 진행합니다
+  script:
+    name: 스크립트
+    desc: JavaScript를 실행합니다
+    code: 코드
+    code_desc: JavaScript 코드
+  trigger:
+    cron:
+      name: Cron
+      desc: cron 일정에 따라 실행합니다
+      schedule: 일정
+      schedule_desc: "Cron 표현식 (참고: https://crontab.cronhub.io/)"
+    entry:
+      name: 항목
+      desc: 파일이나 폴더가 생성, 수정 또는 삭제될 때 실행합니다
+      path_pattern: 경로 패턴
+      path_pattern_desc: "경로와 일치시킬 Glob 패턴이며, 경로는 /로 시작하지 않습니다\n** 는 0개 이상의 디렉터리와 일치합니다;\n* 는 디렉터리 구분자가 아닌 문자를 임의 개수만큼 일치시킵니다;\n? 는 디렉터리 구분자가 아닌 문자 하나와 일치합니다."
+      event_types: 이벤트 유형
+      event_entry_updated: 수정됨
+      event_entry_deleted: 삭제됨

--- a/web/src/i18n/lang/ko-KR.json
+++ b/web/src/i18n/lang/ko-KR.json
@@ -434,6 +434,7 @@
       "prev": "이전",
       "next": "다음",
       "shuffle": "임의 재생",
+      "repeat_one": "한 곡 반복",
       "volume": "볼륨",
       "mute": "음소거",
       "unmute": "음소거 해제",
@@ -441,7 +442,14 @@
     },
     "video": {
       "name": "재생",
-      "desc": "동영상 재생"
+      "desc": "동영상 재생",
+      "play": "재생",
+      "pause": "일시정지",
+      "mute": "음소거",
+      "unmute": "음소거 해제",
+      "fullscreen": "전체 화면",
+      "exit_fullscreen": "전체 화면 종료",
+      "pip": "화면 속 화면"
     },
     "mount": {
       "name": "마운트 위치",

--- a/web/src/i18n/lang/ko-KR.json
+++ b/web/src/i18n/lang/ko-KR.json
@@ -1,0 +1,468 @@
+{
+  "form": {
+    "required_msg": "{f}은(는) 필수 항목입니다",
+    "select_path": "선택"
+  },
+  "routes": {
+    "title": {
+      "site": "사이트",
+      "users": "사용자",
+      "groups": "그룹",
+      "drives": "드라이브",
+      "extra_drives": "추가 드라이브",
+      "jobs": "작업",
+      "path_meta": "경로 속성",
+      "file_buckets": "파일 버킷",
+      "misc": "기타",
+      "statistics": "통계"
+    }
+  },
+  "md": {
+    "error": "마크다운을 렌더링하는 중 오류가 발생했습니다"
+  },
+  "dialog": {
+    "base": {
+      "ok": "확인",
+      "close": "닫기"
+    },
+    "open": {
+      "max_items": "최대 {n}개까지 선택할 수 있습니다.",
+      "n_selected": "{n}개 선택됨.",
+      "clear": "지우기"
+    },
+    "text": {
+      "yes": "예",
+      "no": "아니오"
+    },
+    "loading": {
+      "cancel": "취소"
+    }
+  },
+  "app": {
+    "login": "로그인",
+    "logout": "로그아웃",
+    "home": "홈",
+    "admin": "관리자",
+    "username": "사용자 이름",
+    "groups": "그룹",
+    "file": "파일",
+    "folder": "폴더",
+    "mount_at": "마운트 위치: {n}",
+    "empty_list": "항목이 없습니다",
+    "go_back": "뒤로",
+    "root_path": "루트",
+    "toggle_to_list": "목록 모드로 전환 (T)",
+    "toggle_to_thumbnail": "썸네일 모드로 전환 (T)",
+    "toggle_sort": "정렬 방식 전환",
+    "entry_actions": "파일 작업",
+    "password_protected": "비밀번호 필요",
+    "input_password": "비밀번호를 입력하세요",
+    "sort": {
+      "name_asc": "이름 오름차순",
+      "name_desc": "이름 내림차순",
+      "mod_time_asc": "수정일 오름차순",
+      "mod_time_desc": "수정일 내림차순",
+      "size_asc": "크기 오름차순",
+      "size_desc": "크기 내림차순"
+    },
+    "search": {
+      "placeholder": "파일 검색...",
+      "searching": "검색 중...",
+      "search_help": "다음을 시도해 보세요:",
+      "no_result": "결과 없음"
+    },
+    "task_status_pending": "대기 중",
+    "task_status_running": "실행 중",
+    "task_status_done": "완료됨",
+    "task_status_error": "오류",
+    "task_status_canceled": "취소됨"
+  },
+  "p": {
+    "admin": {
+      "admin_group_required": "'admin' 그룹 권한이 필요합니다",
+      "oauth_connected": "이미 {p}에 연결되어 있습니다",
+      "t_site": "사이트",
+      "t_users": "사용자",
+      "t_groups": "그룹",
+      "t_drives": "드라이브",
+      "t_extra_drives": "추가 드라이브",
+      "t_jobs": "작업",
+      "t_path_meta": "경로 속성",
+      "t_file_buckets": "파일 버킷",
+      "t_misc": "기타",
+      "t_statistics": "통계",
+      "save": "저장",
+      "site": {
+        "site_settings": "사이트",
+        "app_name": "사이트 제목",
+        "global_styles": "전역 CSS",
+        "inject_scripts": "삽입 스크립트",
+        "anonymous_root_path": "익명 사용자 루트 경로",
+        "anonymous_root_path_desc": "로그인하지 않은 사용자가 이 디렉터리 아래의 리소스에만 접근하도록 제한합니다. 경로는 /로 시작하지 않아야 합니다",
+        "file_preview_config": "파일 미리보기 설정",
+        "external_file_viewers": "외부 파일 뷰어",
+        "external_file_viewers_desc": "서드파티 서비스로 파일을 미리 봅니다(참고: 서드파티가 제공하는 서비스라면 해당 서비스가 이 애플리케이션에 접근할 수 있어야 합니다). 설정 형식은 한 줄에 하나씩: [파일 확장자 목록(쉼표로 구분)]<공백>[URL 템플릿]<공백>[서비스 이름]. #으로 시작하는 줄은 주석으로 처리되어 무시됩니다.",
+        "text_file_exts": "텍스트 파일 확장자",
+        "text_file_exts_desc": "보기 및 편집을 지원하는 텍스트 파일 확장자 목록(또는 '/'로 시작하는 전체 파일 이름 매칭, 예: '/.gitignore'), 쉼표로 구분",
+        "image_file_exts": "이미지 파일 확장자",
+        "image_file_exts_desc": "지원하는 이미지 파일 확장자 목록, 쉼표로 구분",
+        "audio_file_exts": "오디오 파일 확장자",
+        "audio_file_exts_desc": "지원하는 오디오 파일 확장자 목록, 쉼표로 구분",
+        "video_file_exts": "비디오 파일 확장자",
+        "video_file_exts_desc": "지원하는 비디오 파일 확장자 목록, 쉼표로 구분",
+        "monaco_editor_exts": "Monaco 에디터 사용",
+        "monaco_editor_exts_desc": "쉼표로 구분된 파일 확장자(또는 '/'로 시작하는 전체 파일 이름 매칭, 예: '/.gitignore'). 이 파일들은 Monaco 에디터로 열립니다",
+        "thumbnail_config": "썸네일 설정",
+        "thumbnail_mapping": "썸네일 생성기 매핑",
+        "thumbnail_mapping_tips": "경로별로 썸네일 생성에 사용할 태그를 설정합니다. 한 줄에 하나의 규칙을 입력하세요. 형식: tag1,tag2:경로-패턴\n마운트된 경로와 chroot된 경로는 매칭을 위해 절대 경로로 해석됩니다\n\n**는 0개 이상의 디렉터리와 일치;\n*는 경로 구분자가 아닌 임의의 문자열과 일치;\n?는 경로 구분자가 아닌 단일 문자와 일치.",
+        "thumbnail_mapping_placeholder": "예: a,b:Pictures/**/*.jpg",
+        "thumbnail_mapping_invalid": "잘못된 매핑 패턴입니다",
+        "download_options": "다운로드 옵션",
+        "proxy_max": "최대 프록시 크기",
+        "proxy_max_desc": "프록시를 통해 다운로드할 수 있는 최대 파일 크기입니다. 단위: b, k, m, g, t",
+        "zip_max_size": "ZIP 다운로드 최대 허용 크기",
+        "zip_max_size_desc": "압축하여 다운로드할 수 있는 파일의 최대 총 크기입니다. 단위: b, k, m, g, t"
+      },
+      "drive": {
+        "reload_drives": "드라이브 다시 불러오기",
+        "reload_tip": "적용하려면 드라이브를 다시 불러와야 합니다",
+        "name": "이름",
+        "type": "유형",
+        "operation": "작업",
+        "edit": "편집",
+        "delete": "삭제",
+        "add_drive": "드라이브 추가",
+        "edit_drive": "드라이브 편집: {n}",
+        "save": "저장",
+        "cancel": "취소",
+        "configure": "설정",
+        "start_configure": "설정",
+        "configured": "설정됨",
+        "not_configured": "설정되지 않음",
+        "add": "추가",
+        "or_edit": " 또는 드라이브 편집",
+        "f_name": "이름",
+        "f_enabled": "활성화",
+        "f_type": "유형",
+        "delete_drive": "드라이브 삭제",
+        "confirm_delete": "드라이브 {n}을(를) 삭제하시겠습니까?",
+        "reload_tips": "변경 사항을 적용하려면 드라이브를 다시 불러와야 합니다"
+      },
+      "extra_drive": {
+        "name": "이름",
+        "scripts": "스크립트",
+        "ops": "작업",
+        "install": "설치",
+        "uninstall": "제거",
+        "edit": "편집",
+        "uninstall_confirm": "삭제하시겠습니까?",
+        "save": "저장",
+        "refresh_repository": "저장소에서 다시 가져오기"
+      },
+      "user": {
+        "username": "사용자 이름",
+        "operation": "작업",
+        "add_user": "사용자 추가",
+        "edit": "편집",
+        "delete": "삭제",
+        "edit_user": "사용자 {n} 편집",
+        "groups": "그룹",
+        "groups_managed_externally": "이 사용자의 그룹은 외부 인증 제공자({s})에서 관리되므로 여기서 편집할 수 없습니다.",
+        "save": "저장",
+        "cancel": "취소",
+        "add": "추가",
+        "or_edit": " 또는 사용자 편집",
+        "f_username": "사용자 이름",
+        "f_password": "비밀번호",
+        "f_rootPath": "루트 경로",
+        "f_rootPath_desc": "사용자가 이 디렉터리 아래의 리소스에만 접근하도록 제한합니다(admin 그룹의 사용자는 이 제한을 무시합니다). 경로는 /로 시작하지 않아야 합니다",
+        "f_rootPath_admin": "admin 그룹의 구성원은 제한이 없으므로 루트 경로가 적용되지 않습니다.",
+        "delete_user": "사용자 삭제",
+        "confirm_delete": "사용자 {n}을(를) 삭제하시겠습니까?"
+      },
+      "group": {
+        "name": "이름",
+        "operation": "작업",
+        "add_group": "그룹 추가",
+        "edit": "편집",
+        "delete": "삭제",
+        "edit_group": "그룹 {n} 편집",
+        "users": "사용자",
+        "user_managed_externally": "외부 인증 제공자({s})에서 관리됨",
+        "external_user_tips": "회색으로 표시된 사용자는 외부 인증 제공자(예: LDAP) 소속이며, 그룹 소속은 해당 제공자가 관리하므로 여기서 변경할 수 없습니다.",
+        "save": "저장",
+        "cancel": "취소",
+        "add": "추가",
+        "or_edit": " 또는 그룹 편집",
+        "f_name": "이름",
+        "f_rootPath": "루트 경로",
+        "f_rootPath_desc": "이 그룹의 구성원이 이 디렉터리 아래의 리소스에만 접근하도록 제한합니다(admin 그룹의 사용자는 이 제한을 무시합니다). 경로는 /로 시작하지 않아야 합니다. 사용자 개인의 루트 경로가 우선 적용되며, 그렇지 않은 경우 사용자가 속한 여러 그룹 중 경로 깊이가 가장 얕은 그룹의 설정이 적용됩니다.",
+        "delete_group": "그룹 삭제",
+        "confirm_delete": "그룹 {n}을(를) 삭제하시겠습니까?"
+      },
+      "path_meta": {
+        "add": "추가",
+        "path": "경로",
+        "password": "비밀번호",
+        "def_sort": "기본 정렬",
+        "def_mode": "기본 표시 방식",
+        "hidden_pattern": "숨김 패턴",
+        "operation": "작업",
+        "edit": "편집",
+        "delete": "삭제",
+        "save": "저장",
+        "cancel": "취소",
+        "delete_item": "삭제",
+        "confirm_delete": "삭제하시겠습니까?",
+        "f_path": "경로",
+        "f_password": "디렉터리 비밀번호",
+        "f_password_desc": "디렉터리 비밀번호를 설정하면 익명 사용자는 디렉터리 내용을 보기 위해 비밀번호를 입력해야 합니다. WebDAV 익명 사용자는 비밀번호로 보호된 디렉터리에 접근할 수 없습니다",
+        "f_password_r": "하위 경로에 적용",
+        "f_def_sort": "기본 정렬",
+        "f_def_sort_r": "하위 경로에 적용",
+        "f_def_mode": "기본 목록 모드",
+        "f_def_mode_r": "하위 경로에 적용",
+        "f_hidden_pattern": "숨김 파일 패턴",
+        "f_hidden_pattern_desc": "이 디렉터리에서 숨길 파일(폴더) 이름의 정규식을 설정합니다(표시할 때만 숨김 처리됨). 예: .*\\.mp4$",
+        "f_hidden_pattern_r": "하위 경로에 적용",
+        "fo_mode_list": "목록",
+        "fo_mode_thumbnail": "썸네일"
+      },
+      "file_bucket": {
+        "edit": "편집",
+        "add": "추가",
+        "delete": "삭제",
+        "save": "저장",
+        "cancel": "취소",
+        "name": "이름",
+        "target_path": "대상 경로",
+        "operation": "작업",
+        "f_name": "이름",
+        "f_name_desc": "이름은 이 파일 버킷의 고유 식별자이며, 파일 업로드나 접근 시 URL의 일부이기도 합니다",
+        "f_target_path": "대상 경로",
+        "f_target_path_desc": "파일 버킷의 대상 경로입니다. /로 시작하지 않아야 합니다",
+        "f_key_template": "파일 경로 템플릿",
+        "f_key_template_desc": "이 버킷에 파일을 업로드할 때 사용할 파일 경로 템플릿입니다. 다음 변수를 지원합니다:\n{'{'}year{'}'}: 연도\n{'{'}month{'}'}: 월\n{'{'}date{'}'}: 일\n{'{'}hour{'}'}: 시\n{'{'}minute{'}'}: 분\n{'{'}second{'}'}: 초\n{'{'}millisecond{'}'}: 밀리초\n{'{'}timestamp{'}'}: 밀리초 타임스탬프\n{'{'}rand{'}'}: 임의 텍스트\n{'{'}name{'}'}: 파일 이름(확장자 제외)\n{'{'}ext{'}'}: 파일 확장자(예: .jpg)\n\n예: '{'{'}year{'}'}/{'{'}month{'}'}/{'{'}date{'}'}/{'{'}hour{'}'}/{'{'}minute{'}'}/{'{'}second{'}'}/{'{'}name{'}'}{'{'}ext{'}'}'는 '2024/01/28/12/34/56/test.jpg'를 생성합니다\n\n비워두면 기본값을 사용합니다: {'{'}year{'}'}{'{'}month{'}'}{'{'}date{'}'}/{'{'}name{'}'}-{'{'}rand{'}'}{'{'}ext{'}'}",
+        "f_secret_token": "업로드 비밀 키",
+        "f_secret_token_desc": "이 버킷에 파일을 업로드할 때 필요한 키입니다",
+        "f_url_template": "다운로드 URL 템플릿",
+        "f_url_template_desc": "업로드 시 반환되는 파일 다운로드 링크에 사용할 URL 템플릿입니다. 다음 변수를 지원합니다:\n{'{'}origin{'}'}: 현재 서버 API 접두사, 예: https://example.com/api\n{'{'}bucket{'}'}: 파일 버킷 이름\n{'{'}key{'}'}: 파일 경로\n\n비워두면 기본값을 사용합니다: {'{'}origin{'}'}/f/{'{'}bucket{'}'}/{'{'}key{'}'}",
+        "f_custom_key": "업로드 시 사용자 지정 파일 경로 허용",
+        "f_custom_key_desc": "활성화하면 파일 업로드 시 사용자 지정 파일 경로를 사용할 수 있습니다",
+        "f_allowed_types": "업로드 허용 파일 유형",
+        "f_allowed_types_desc": "mime-type 또는 파일 확장자를 지원하며, 여러 개일 경우 쉼표로 구분합니다. 예: image/*,video/mp4,.pdf",
+        "f_max_size": "최대 업로드 파일 크기",
+        "f_max_size_desc": "업로드 파일 크기를 제한합니다. b, k, m, g, t 등의 단위를 사용할 수 있습니다",
+        "f_allowed_referrers": "허용된 Referer 목록",
+        "f_allowed_referrers_desc": "허용된 Referer 목록입니다. 여러 개일 경우 쉼표로 구분하며, 비워두면 기본적으로 핫링크 방지가 꺼집니다. *를 사용해 서브도메인을 매칭할 수 있고, 빈 도메인을 사용하면 빈 Referer를 허용합니다.\n예: example.com,*.example.com은 example.com과 그 서브도메인을 허용합니다. example.com,,*.example.com은 example.com과 그 서브도메인, 그리고 빈 Referer를 허용합니다",
+        "f_cache_max_age": "다운로드 캐시 TTL",
+        "f_cache_max_age_desc": "파일 접근 캐시 시간(Cache-Control)입니다. 유효한 단위는 ms, s, m, h, d이며 기본값은 하루입니다.",
+        "delete_item": "삭제",
+        "confirm_delete": "삭제하시겠습니까?",
+        "upload_api_p_path": "<업로드 경로>",
+        "upload_api_p_secret_token": "<비밀 키>",
+        "upload_help_doc_md": "다음 API를 사용하여 파일을 업로드하세요:\n  ```\n  POST {api}\n  ```\n  \n  **업로드 시 사용자 지정 파일 경로 허용**이 활성화된 경우, 다음 API로도 파일을 업로드할 수 있습니다:\n  \n  ```\n  POST {api_with_path}\n  ```\n  \n  > 두 가지 업로드 형식을 지원합니다: 파일 스트림 직접 업로드 또는 폼 업로드. 폼 업로드를 사용할 때 파일의 `key`는 `file`입니다.\n  \n  <details>\n  <summary>cURL로 파일 업로드하기</summary>\n  \n  ```bash\n  curl -F 'file={'@'}FILE_PATH' '{api}' # 폼 업로드\n  curl -X POST --data-binary {'@'}FILE_PATH '{api}' # 파일 스트림 직접 업로드\n  ```\n  </details>\n  "
+      },
+      "jobs": {
+        "job": "작업",
+        "enabled": "활성화",
+        "triggers": "트리거",
+        "triggers_desc": "이 작업이 실행되는 시점을 설정합니다",
+        "trigger_cron": "Cron",
+        "trigger_entry_event_updated": "업데이트됨",
+        "trigger_entry_event_deleted": "삭제됨",
+        "add_trigger": "트리거 추가",
+        "trigger_required": "트리거를 최소 하나 이상 추가해야 합니다",
+        "stats": "통계",
+        "stats_nextRun": "다음 실행",
+        "desc": "설명",
+        "add_job": "작업 추가",
+        "edit_job": "작업 편집",
+        "view_log": "실행 로그 보기",
+        "job_executions": "실행 로그: {n}",
+        "operation": "작업",
+        "edit": "편집",
+        "execute": "실행",
+        "delete": "삭제",
+        "save": "저장",
+        "cancel": "취소",
+        "delete_job": "작업 삭제",
+        "abort_execution": "실행 중단",
+        "confirm_abort_execution": "이 실행을 중단하시겠습니까?",
+        "confirm_delete": "삭제하시겠습니까?",
+        "execute_of": "실행: {name}",
+        "abort": "중단",
+        "close": "닫기",
+        "eval_code": "코드 실행",
+        "eval_code_log": "로그",
+        "status": "상태",
+        "started_at": "시작 시각",
+        "completed_at": "완료 시각",
+        "execution_duration": "소요 시간",
+        "logs": "로그",
+        "error_msg": "오류 메시지",
+        "success": "성공",
+        "failed": "실패",
+        "running": "실행 중"
+      },
+      "misc": {
+        "permission_of_root": "루트 권한",
+        "clean": "정리",
+        "clean_invalid": "유효하지 않은 권한 및 마운트 정리",
+        "clean_cache": "캐시 지우기",
+        "refresh_in": "{n}초 후 새로고침",
+        "invalid_path_cleaned": "유효하지 않은 경로 {n}개를 정리했습니다",
+        "search_index": "파일 색인",
+        "search_disabled": "검색 기능이 활성화되어 있지 않습니다",
+        "search_form_filter": "필터",
+        "search_form_filter_desc": "한 줄에 하나의 필터를 입력하세요. +로 시작하는 줄은 포함, -로 시작하는 줄은 제외를 의미합니다. 비워두면 모든 파일을 포함합니다.\n** 는 0개 이상의 디렉터리와 일치;\n* 는 경로 구분자가 아닌 임의의 문자열과 일치;\n? 는 경로 구분자가 아닌 단일 문자와 일치.",
+        "search_form_filter_placeholder": "예:\n-**/node_modules/**\n+**/*.jpg\n+**/*.png",
+        "search_form_filter_invalid": "잘못된 필터입니다",
+        "search_form_path": "경로",
+        "search_form_path_desc": "비워두면 모든 파일을 색인합니다",
+        "search_submit_index": "지금 색인",
+        "search_th_path": "경로",
+        "search_th_status": "상태",
+        "search_th_created_at": "시작 시각",
+        "search_th_updated_at": "업데이트 시각",
+        "search_th_ops": "작업",
+        "search_index_stop": "중지",
+        "search_op_index": "색인",
+        "search_op_delete": "삭제"
+      },
+      "p_edit": {
+        "subject": "대상",
+        "rw": "(읽기/쓰기)",
+        "policy": "정책",
+        "any": "모두",
+        "reject": "거부",
+        "accept": "허용"
+      }
+    },
+    "task": {
+      "empty": "항목이 없습니다",
+      "start": "시작",
+      "pause": "일시정지",
+      "stop": "중지",
+      "remove": "제거",
+      "s_created": "생성됨",
+      "s_starting": "시작 중",
+      "s_paused": "일시정지됨",
+      "s_stopped": "중지됨",
+      "s_error": "오류",
+      "s_completed": "완료됨"
+    },
+    "home": {
+      "readme_loading": "README 불러오는 중...",
+      "readme_failed": "README를 불러오지 못했습니다.",
+      "unsaved_confirm": "저장되지 않은 변경 사항이 있습니다. 나가시겠습니까?"
+    },
+    "new_entry": {
+      "new_item": "새 항목",
+      "create_file": "빈 파일 만들기",
+      "upload_file": "파일 업로드",
+      "create_folder": "폴더 만들기",
+      "upload_tasks": "업로드 작업",
+      "tasks_status": "작업 {p}",
+      "drop_tip": "여기에 파일을 놓으면 업로드됩니다",
+      "invalid_filename": "잘못된 파일 이름입니다",
+      "invalid_folder_name": "잘못된 폴더 이름입니다",
+      "confirm_stop_task": "이 작업을 중지하시겠습니까?",
+      "confirm_remove_task": "이 작업을 제거하시겠습니까? 되돌릴 수 없습니다.",
+      "resolve_file": "파일/디렉터리 {n}개...",
+      "upload_clipboard": "클립보드의 파일을 업로드하시겠습니까?"
+    },
+    "login": {
+      "username": "사용자 이름",
+      "password": "비밀번호",
+      "login": "로그인"
+    }
+  },
+  "hv": {
+    "download": {
+      "download": "다운로드",
+      "downloads": "파일 {n}개 다운로드"
+    },
+    "permission": {
+      "save": "저장"
+    },
+    "text_edit": {
+      "save": "저장"
+    }
+  },
+  "handler": {
+    "copy_move": {
+      "copy": "복사",
+      "move": "이동",
+      "copy_to": "복사 위치",
+      "move_to": "이동 위치",
+      "copy_desc": "파일 복사",
+      "move_desc": "파일 이동",
+      "copying": "{n}{p} 복사 중",
+      "moving": "{n}{p} 이동 중",
+      "copy_open_title": "복사 위치 선택",
+      "move_open_title": "이동 위치 선택"
+    },
+    "zip": {
+      "name": "ZIP 다운로드",
+      "desc": "ZIP 압축 파일 생성"
+    },
+    "delete": {
+      "name": "삭제",
+      "desc": "파일 삭제",
+      "confirm_n": "이 파일 {n}개를 삭제하시겠습니까?",
+      "confirm": "이 파일을 삭제하시겠습니까?",
+      "deleting": "{n}{p} 삭제 중"
+    },
+    "download": {
+      "name": "다운로드",
+      "desc": "파일 다운로드"
+    },
+    "image": {
+      "name": "갤러리",
+      "desc": "이미지 보기"
+    },
+    "iframe": {
+      "name": "미리보기",
+      "desc": "이 파일 미리보기"
+    },
+    "audio": {
+      "name": "재생",
+      "desc": "음악 재생",
+      "play": "재생",
+      "pause": "일시정지",
+      "prev": "이전",
+      "next": "다음",
+      "shuffle": "임의 재생",
+      "volume": "볼륨",
+      "mute": "음소거",
+      "unmute": "음소거 해제",
+      "playlist": "재생 목록"
+    },
+    "video": {
+      "name": "재생",
+      "desc": "동영상 재생"
+    },
+    "mount": {
+      "name": "마운트 위치",
+      "desc": "다른 위치로 항목 마운트",
+      "open_title": "마운트 위치 선택"
+    },
+    "permission": {
+      "name": "권한",
+      "desc": "이 항목의 권한 설정"
+    },
+    "rename": {
+      "name": "이름 바꾸기",
+      "desc": "이 파일 이름 바꾸기",
+      "input_title": "이름 바꾸기",
+      "invalid_filename": "잘못된 파일 이름입니다"
+    },
+    "text_edit": {
+      "edit_name": "편집",
+      "view_name": "보기",
+      "edit_desc": "이 파일 편집",
+      "view_desc": "이 파일 보기"
+    }
+  }
+}


### PR DESCRIPTION
## Motivation

This adds Korean (`ko`) translation support — to help Korean-speaking users use this
open-source project more comfortably in their own language.
(한국 사람들의 오픈소스 이용에 도움이 되게 하기 위해서 한글화 작업을 하였습니다.)

## Changes

- Added `web/src/i18n/lang/ko-KR.json`, a full Korean translation of every key in
  `web/src/i18n/lang/en-US.json` (376 keys), following the same structure and
  naming convention as the existing `zh-CN.json`.
- No separate language-registration list needed to be updated: `web/src/i18n/index.ts`
  loads locale files dynamically (`import('./lang/${lang}.json')`) based on
  `navigator.language` / `setLang()`, so adding `ko-KR.json` is sufficient for the
  app to pick it up automatically for Korean browsers.

## Testing

- Verified with a script that the key set of `ko-KR.json` exactly matches
  `en-US.json` (376/376 keys, 0 missing, 0 extra).
- Verified all interpolation placeholders (e.g. `{n}`, `{f}`, `{p}`, `{s}`,
  `{name}`, `{api}`, and the escaped `{'{'}...{'}'}` template-variable docs in
  `file_bucket`) are preserved identically between `en-US.json` and `ko-KR.json`.
- Manually re-read the Korean text for naturalness and consistency of terminology
  (e.g. 드라이브/그룹/권한/마운트) across the file.