### PR TITLE
feat(web): add platform-aware shortcuts

### DIFF
--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -53,12 +53,14 @@ See the [drive overview](./drives/) for configuration details and capability lim
 
 ## Useful shortcuts
 
-> On macOS, `Ctrl` refers to the <kbd>⌃ Control</kbd> key (not <kbd>⌘ Command</kbd>), and `Alt` refers to the <kbd>⌥ Option</kbd> key.
+> File-browser shortcuts use <kbd>⌘ Command</kbd> on macOS and <kbd>Ctrl</kbd> on other platforms. `Alt` refers to the <kbd>⌥ Option</kbd> key on macOS.
 
-- Click the icon or thumbnail at the left of a row to toggle that entry's selection. `Ctrl` + click also toggles entries; `Shift` + click in a row selects a range from the most recently selected entry.
-- Copy files in your operating system and press `Ctrl+V`: paste-upload them.
+- Press `Command+K` on macOS or `Ctrl+K` elsewhere to open file search.
+- Click the icon or thumbnail at the left of a row to toggle that entry's selection. `Command`/`Ctrl` + click also toggles entries; `Shift` + click in a row selects a range from the most recently selected entry.
+- Press `Command+A` on macOS or `Ctrl+A` elsewhere to select or clear all entries.
+- Copy files in your operating system and paste them with `Command+V` on macOS or `Ctrl+V` elsewhere to upload them.
 - `Alt` + click a file: download it directly.
-- Drag entries onto a writable folder to move them. If the source cannot be moved, they are copied instead. Hold `Ctrl` to copy; hold `Shift` to create a path mount (administrators only).
+- Drag entries onto a writable folder to move them. If the source cannot be moved, they are copied instead. Hold `Command` on macOS or `Ctrl` elsewhere to copy; hold `Shift` to create a path mount (administrators only).
 - Use the file context menu (long-press on mobile) for permissions, mounts, rename, and other operations.
 
 ## Getting help

--- a/docs/site/zh-CN/index.md
+++ b/docs/site/zh-CN/index.md
@@ -4,7 +4,7 @@ titleTemplate: false
 description: 使用一台自托管 go-drive 服务器统一管理本地文件、S3、WebDAV、FTP、SFTP、OneDrive 和 Google Drive。
 lang: zh-CN
 translation_key: home
-source_hash: 67a89ae7a73193d381b3c0b720d888f7bbaba90603bfc9f50b2947d4181eb7a0
+source_hash: eca33cdda3533f2d5539f0f0c315870b01d9802919dd3c7ee42e3dd5d7f6afca
 ---
 
 # go-drive
@@ -54,12 +54,14 @@ docker run -d --name go-drive \
 
 ## 常用操作提示
 
-> macOS 上 `Ctrl` 指 <kbd>⌃ Control</kbd> 键（不是 <kbd>⌘ Command</kbd>），`Alt` 指 <kbd>⌥ Option</kbd> 键。
+> 文件浏览器快捷键在 macOS 上使用 <kbd>⌘ Command</kbd>，在其他平台上使用 <kbd>Ctrl</kbd>；macOS 上的 `Alt` 指 <kbd>⌥ Option</kbd> 键。
 
-- 单击条目左侧的图标或缩略图可切换该条目的选中状态。`Ctrl` + 单击也可切换选中；按住 `Shift` 单击，可从最近选中的条目开始范围选择。
-- 从系统复制文件后按 `Ctrl+V`：粘贴上传。
+- macOS 按 `Command+K`、其他平台按 `Ctrl+K`，可打开文件搜索。
+- 单击条目左侧的图标或缩略图可切换该条目的选中状态。`Command`/`Ctrl` + 单击也可切换选中；按住 `Shift` 单击，可从最近选中的条目开始范围选择。
+- macOS 按 `Command+A`、其他平台按 `Ctrl+A`，可全选或取消全选条目。
+- 从系统复制文件后，macOS 按 `Command+V`、其他平台按 `Ctrl+V`，可粘贴上传。
 - `Alt` + 单击文件：直接下载。
-- 将条目拖到可写文件夹中可执行移动；源位置不允许移动时会改为复制。拖拽时按 `Ctrl`：复制；按 `Shift`：创建路径挂载（管理员）。
+- 将条目拖到可写文件夹中可执行移动；源位置不允许移动时会改为复制。拖拽时，macOS 按 `Command`、其他平台按 `Ctrl`：复制；按 `Shift`：创建路径挂载（管理员）。
 - 文件右键菜单（移动端长按）：权限、挂载、重命名等操作。
 
 ## 获取帮助

--- a/web/src/components/entry/EntryList.vue
+++ b/web/src/components/entry/EntryList.vue
@@ -125,6 +125,7 @@
 import { Entry } from '@/types'
 import { isRootPath as isRootPathFn, mapOf, pathClean, pathJoin } from '@/utils'
 import { useHotKey } from '@/utils/hooks/hotkey'
+import { isPrimaryModifierPressed } from '@/utils/platform'
 import {
   ComponentPublicInstance,
   computed,
@@ -254,8 +255,8 @@ watch(sortedEntries, (entries) => emit('entries-change', entries))
 
 const entryClicked = (e: EntryEventData) => {
   const event = e.event as MouseEvent | undefined
-  if (event?.ctrlKey) {
-    // toggle selection if ctrl key is pressed
+  if (event && isPrimaryModifierPressed(event)) {
+    // Toggle selection with Command on macOS and Ctrl elsewhere.
     event.preventDefault()
     if (e.entry!.name === '..') return
     toggleSelect(e.entry!)
@@ -397,7 +398,7 @@ useHotKey(
     e.preventDefault()
   },
   'a',
-  { ctrl: true }
+  { primary: true }
 )
 
 defineExpose({
@@ -456,7 +457,7 @@ defineExpose({
   display: flex;
   gap: 8px;
   margin-left: auto;
-  align-items: flex-start;
+  align-items: center;
 
   .icon {
     color: var(--color-text-muted);

--- a/web/src/components/entry/useDrag.ts
+++ b/web/src/components/entry/useDrag.ts
@@ -2,6 +2,7 @@ import { useAppStore } from '@/store'
 import { Entry } from '@/types'
 import { isParentPath, pathClean, pathJoin } from '@/utils'
 import { addEntryIntoDataTransfer, DATA_TYPE_ENTRY } from '@/utils/entry'
+import { isPrimaryModifierPressed } from '@/utils/platform'
 import { Ref, ref } from 'vue'
 import { EntryEventData } from '.'
 
@@ -66,7 +67,7 @@ const emptyDragState = (): EntryDragState => ({
 })
 
 const getModifiers = (event: DragEvent): EntryDragModifiers => ({
-  copy: event.ctrlKey,
+  copy: isPrimaryModifierPressed(event),
   link: event.shiftKey,
 })
 

--- a/web/src/handlers/text-edit/TextEditView.vue
+++ b/web/src/handlers/text-edit/TextEditView.vue
@@ -42,6 +42,7 @@ import TextEditor from '@/components/TextEditor/index.vue'
 import { Entry } from '@/types'
 import { entryMatches, filename as filenameFn, filenameExt } from '@/utils'
 import { HttpError } from '@/utils/http'
+import { isPrimaryModifierPressed } from '@/utils/platform'
 import { alert } from '@/utils/ui-utils'
 import { computed, nextTick, ref, watch } from 'vue'
 import { EntryHandlerContext } from '../types'
@@ -136,7 +137,13 @@ const changeSaveState = (saved: boolean) => {
 }
 
 const onKeyDown = (e: KeyboardEvent) => {
-  if (e.key === 's' && (e.ctrlKey || e.metaKey) && !readonly.value) {
+  if (
+    e.key === 's' &&
+    isPrimaryModifierPressed(e) &&
+    !e.altKey &&
+    !e.shiftKey &&
+    !readonly.value
+  ) {
     e.preventDefault()
     saveFile()
   }

--- a/web/src/utils/hooks/hotkey.ts
+++ b/web/src/utils/hooks/hotkey.ts
@@ -1,4 +1,5 @@
 import { onBeforeUnmount, onMounted } from 'vue'
+import { isMacOS } from '@/utils/platform'
 
 interface HotKey_ {
   handler: (this: HTMLElement, e: KeyboardEvent) => void
@@ -50,17 +51,31 @@ export const useHotKey = (
   key: string | string[] | Fn1<KeyboardEvent, boolean>,
   {
     ctrl,
+    meta,
+    primary,
     alt,
     shift,
     el,
   }: {
     ctrl?: boolean
+    meta?: boolean
+    primary?: boolean
     alt?: boolean
     shift?: boolean
     el?: HTMLElement | (() => HTMLElement)
   } = {}
 ) => {
+  if (primary && (ctrl || meta)) {
+    throw new Error('primary cannot be combined with ctrl or meta')
+  }
+
+  const macOS = isMacOS()
+  if (primary) {
+    ctrl = !macOS
+    meta = macOS
+  }
   ctrl = !!ctrl
+  meta = !!meta
   alt = !!alt
   shift = !!shift
 
@@ -81,6 +96,7 @@ export const useHotKey = (
     el_._hotkey.events.push({
       auxMatched: (e) =>
         !(+ctrl! ^ +e.ctrlKey) &&
+        !(+meta! ^ +e.metaKey) &&
         !(+alt! ^ +e.altKey!) &&
         !(+shift! ^ +e.shiftKey),
       keyMatched: genKeyMatched(key),

--- a/web/src/utils/platform.ts
+++ b/web/src/utils/platform.ts
@@ -1,0 +1,10 @@
+type ModifierEvent = Pick<KeyboardEvent, 'ctrlKey' | 'metaKey'>
+
+export const isMacOS = () =>
+  typeof navigator !== 'undefined' &&
+  /Macintosh|Mac OS X/.test(navigator.userAgent)
+
+export const isPrimaryModifierPressed = (event: ModifierEvent) =>
+  isMacOS()
+    ? event.metaKey && !event.ctrlKey
+    : event.ctrlKey && !event.metaKey

--- a/web/src/views/EntryExplorer/SearchPanel/index.vue
+++ b/web/src/views/EntryExplorer/SearchPanel/index.vue
@@ -18,7 +18,6 @@
         @keydown.stop
         @focus="onInputFocus"
       />
-      <span class="search-panel__search-input-key">F</span>
     </div>
     <div v-if="showing" class="search-panel__result" @scroll="onResultScroll">
       <div v-if="result.length === 0" class="search-panel__tip">
@@ -158,7 +157,7 @@ const setActive = (active: boolean) => {
 useHotKey((e) => {
   e.preventDefault()
   setActive(true)
-}, 'f')
+}, 'k', { primary: true })
 
 useHotKey(
   () => {
@@ -195,14 +194,6 @@ defineExpose({ setActive })
 
   &.active {
     box-shadow: var(--shadow-elevated);
-
-    .search-panel__search {
-      padding-right: 16px;
-    }
-
-    .search-panel__search-input-key {
-      display: none;
-    }
   }
 }
 
@@ -212,28 +203,7 @@ defineExpose({ setActive })
 }
 
 .search-panel__search {
-  position: relative;
-  padding: 0 36px 0 16px;
-  transition: padding-right var(--motion-duration-normal)
-    var(--motion-easing-standard);
-}
-
-.search-panel__search-input-key {
-  position: absolute;
-  display: block;
-  top: 50%;
-  right: 16px;
-  transform: translateY(-50%);
-  width: 16px;
-  height: 16px;
-  line-height: 16px;
-  text-align: center;
-  font-size: 14px;
-  color: var(--color-text-muted);
-  -webkit-user-select: none;
-  user-select: none;
-  border-radius: 2px;
-  border: solid 1px var(--color-field-border);
+  padding: 0 16px;
 }
 
 .search-panel__search-input {


### PR DESCRIPTION
## What changed

- introduce a shared platform-aware primary modifier (`Command` on macOS, `Ctrl` elsewhere)
- move file search from `F` to primary-modifier + `K`
- apply the platform-aware modifier to select-all, modifier-click selection, drag-copy, and text-editor save
- document the shortcuts in the English and Chinese documentation

## Why

The frontend previously treated `Ctrl` and `Command` inconsistently. Some shortcuts accepted both, some only accepted `Ctrl`, and unmodified shortcuts could also match events carrying `Command` because `metaKey` was not checked.

This makes shortcut behavior follow platform conventions while preventing the non-primary modifier from triggering the same action.

## User impact

- macOS users use `Command+K`, `Command+A`, and `Command+S`
- Windows and Linux users use `Ctrl+K`, `Ctrl+A`, and `Ctrl+S`
- modifier-click selection and drag-copy follow the same platform convention

## Validation

- `npm run lint` in `web/`
- `npm run build-web` in `web/`
- `npm run build` in `docs/site/`
- `git diff --check`