### PR TITLE
feat(api): normalize backend routes

### DIFF
--- a/docs/config.yml
+++ b/docs/config.yml
@@ -130,7 +130,8 @@ thumbnail:
     # GO_DRIVE_ENTRY_NAME: the entry name
     # GO_DRIVE_ENTRY_SIZE: the entry file size
     # GO_DRIVE_ENTRY_MOD_TIME: timestamp, modTime of this entry
-    # GO_DRIVE_ENTRY_URL: URL of the file content or folder children (e.g. /content/a/a.txt or /entries/a)
+    # GO_DRIVE_ENTRY_URL: URL of the file content or folder children
+    # (e.g. /download?path=a/a.txt or /list?path=a)
     # media: generate thumbnails for video and audio files via ffmpeg.
     # For video it grabs the first frame; for audio it grabs the embedded cover
     # (poster/album art), which ffmpeg exposes as a video stream, so `-frames:v 1`

--- a/server/api_admin.go
+++ b/server/api_admin.go
@@ -42,25 +42,25 @@ func InitAdminRoutes(
 	// list users
 	r.GET("/users", ur.listUsers)
 	// get user by username
-	r.GET("/user/:username", ur.getUser)
+	r.GET("/users/:username", ur.getUser)
 	// create user
-	r.POST("/user", ur.createUser)
+	r.POST("/users", ur.createUser)
 	// update user
-	r.PUT("/user/:username", ur.updateUser)
+	r.PUT("/users/:username", ur.updateUser)
 	// delete user
-	r.DELETE("/user/:username", ur.deleteUser)
+	r.DELETE("/users/:username", ur.deleteUser)
 
 	gr := &groupsRoute{groupDAO}
 	// list groups
 	r.GET("/groups", gr.listGroups)
 	// get group and it's users
-	r.GET("/group/:name", gr.getGroup)
+	r.GET("/groups/:name", gr.getGroup)
 	// create group
-	r.POST("/group", gr.createGroup)
+	r.POST("/groups", gr.createGroup)
 	// update group
-	r.PUT("/group/:name", gr.updateGroup)
+	r.PUT("/groups/:name", gr.updateGroup)
 	// delete group
-	r.DELETE("/group/:name", gr.deleteGroup)
+	r.DELETE("/groups/:name", gr.deleteGroup)
 
 	dr := &drivesRoute{config, driveDAO, driveDataDAO, rootDrive}
 	// get drive factories
@@ -68,15 +68,15 @@ func InitAdminRoutes(
 	// get drives
 	r.GET("/drives", dr.getDrives)
 	// add drive
-	r.POST("/drive", dr.createDrive)
+	r.POST("/drives", dr.createDrive)
 	// update drive
-	r.PUT("/drive/:name", dr.updateDrive)
+	r.PUT("/drives/:name", dr.updateDrive)
 	// delete drive
-	r.DELETE("/drive/:name", dr.deleteDrive)
+	r.DELETE("/drives/:name", dr.deleteDrive)
 	// get drive initialization information
-	r.POST("/drive/:name/init-config", dr.getDriveInitConfig)
+	r.POST("/drives/:name/init-config", dr.getDriveInitConfig)
 	// init drive
-	r.POST("/drive/:name/init", dr.doDriveInit)
+	r.POST("/drives/:name/init", dr.doDriveInit)
 	// reload drives
 	r.POST("/drives/reload", dr.reloadDrives)
 
@@ -90,16 +90,16 @@ func InitAdminRoutes(
 		bus:           bus,
 	}
 	// get by path
-	r.GET("/path-permissions/*path", cr.getPathPermissions)
+	r.GET("/path-permissions", cr.getPathPermissions)
 	// save path permissions
-	r.PUT("/path-permissions/*path", cr.savePathPermissions)
+	r.PUT("/path-permissions", cr.savePathPermissions)
 
-	// get all path meta
-	r.GET("/path-meta", cr.getAllPathMeta)
-	// create or add path meta
-	r.POST("/path-meta/*path", cr.savePathMeta)
-	// delete path meta by path
-	r.DELETE("/path-meta/*path", cr.deletePathMeta)
+	// get all path metadata
+	r.GET("/path-metadata", cr.getAllPathMeta)
+	// create or update path metadata
+	r.PUT("/path-metadata", cr.savePathMeta)
+	// delete path metadata by path
+	r.DELETE("/path-metadata", cr.deletePathMeta)
 
 	// save options
 	r.PUT("/options", cr.saveOptions)
@@ -107,39 +107,39 @@ func InitAdminRoutes(
 	r.GET("/options/:keys", cr.getOptions)
 
 	// save mounts
-	r.POST("/mount/*to", cr.savePathMounts)
+	r.PUT("/path-mounts", cr.savePathMounts)
 
 	mr := &miscRoute{access, permissionDAO, pathMountDAO, rootDrive, search, ch}
 	// index files
-	r.POST("/search/index/*path", mr.updateSearcherIndexes)
+	r.PUT("/search-indexes", mr.updateSearcherIndexes)
 	// clean all PathPermission and PathMount that is point to invalid path
-	r.POST("/clean-permissions-mounts", mr.cleanupInvalidPathPermissionsAndMounts)
+	r.POST("/maintenance/path-rules/cleanup", mr.cleanupInvalidPathPermissionsAndMounts)
 	// get service stats
 	r.GET("/stats", mr.getSystemStats)
 	// clean drive cache
-	r.DELETE("/drive-cache/:name", mr.clearDriveCache)
+	r.DELETE("/drives/:name/cache", mr.clearDriveCache)
 
 	// region script drives
 
-	scriptDriveRoutesGroup := r.Group("/scripts")
+	scriptDriveRoutesGroup := r.Group("/drive-scripts")
 	sdr := &scriptDrivesRoute{config: config}
 	// get available drives from repository
 	scriptDriveRoutesGroup.GET("/available", sdr.getAvailableDrives)
 	// get installed drives
 	scriptDriveRoutesGroup.GET("/installed", sdr.getInstalledDrives)
 	// install drive
-	scriptDriveRoutesGroup.POST("/install/:name", sdr.installDrive)
+	scriptDriveRoutesGroup.PUT("/:name", sdr.installDrive)
 	// uninstall drive
-	scriptDriveRoutesGroup.DELETE("/uninstall/:name", sdr.uninstallDrive)
+	scriptDriveRoutesGroup.DELETE("/:name", sdr.uninstallDrive)
 	// get drive script content
-	scriptDriveRoutesGroup.GET("/content/:name", sdr.getDriveScriptContent)
+	scriptDriveRoutesGroup.GET("/:name/content", sdr.getDriveScriptContent)
 	// update drive script content
-	scriptDriveRoutesGroup.PUT("/content/:name", sdr.saveDriveScriptContent)
+	scriptDriveRoutesGroup.PUT("/:name/content", sdr.saveDriveScriptContent)
 
 	jobsRoutesGroup := r.Group("/jobs")
 	jr := &jobsRoute{ch, runner, jobExecutor, jobDAO}
 	// get all job definitions
-	jobsRoutesGroup.GET("/definitions", jr.getJobsDefinitions)
+	r.GET("/job-definitions", jr.getJobsDefinitions)
 	// get all created jobs
 	jobsRoutesGroup.GET("", jr.getJobs)
 	// create job
@@ -149,27 +149,27 @@ func InitAdminRoutes(
 	// delete job
 	jobsRoutesGroup.DELETE("/:id", jr.deleteJob)
 	// get all executions
-	jobsRoutesGroup.GET("/executions", jr.getAllExecutions)
+	r.GET("/job-executions", jr.getAllExecutions)
 	// execute a job
-	jobsRoutesGroup.POST("/execution", jr.executeJob)
+	r.POST("/job-executions", jr.executeJob)
 	// cancel job execution
-	jobsRoutesGroup.PUT("/execution/:id/cancel", jr.cancelJobExecution)
+	r.POST("/job-executions/:id/cancel", jr.cancelJobExecution)
 	// delete job execution
-	jobsRoutesGroup.DELETE("/execution/:id", jr.deleteJobExecution)
+	r.DELETE("/job-executions/:id", jr.deleteJobExecution)
 	// delete job executions by jobId
-	jobsRoutesGroup.DELETE("/execution", jr.deleteJobExecutionsByJobId)
+	r.DELETE("/job-executions", jr.deleteJobExecutionsByJobId)
 	// execute job script code
-	jobsRoutesGroup.POST("/script-eval", jr.scriptEval)
+	r.POST("/job-script-evaluations", jr.scriptEval)
 
 	fbr := &fileBucketConfigRoute{fileBucketDAO}
 	// get all file buckets
 	r.GET("/file-buckets", fbr.getAllBuckets)
 	// create file bucket
-	r.POST("/file-bucket", fbr.createBucket)
+	r.POST("/file-buckets", fbr.createBucket)
 	// update file bucket
-	r.PUT("/file-bucket/:name", fbr.updateBucket)
+	r.PUT("/file-buckets/:name", fbr.updateBucket)
 	// delete file bucket
-	r.DELETE("/file-bucket/:name", fbr.deleteBucket)
+	r.DELETE("/file-buckets/:name", fbr.deleteBucket)
 
 	return nil
 }

--- a/server/api_admin_config.go
+++ b/server/api_admin_config.go
@@ -28,7 +28,11 @@ type configRoute struct {
 }
 
 func (cr *configRoute) getPathPermissions(c *gin.Context) {
-	path := utils.CleanPath(c.Param("path"))
+	path, e := getQueryPath(c, "path")
+	if e != nil {
+		_ = c.Error(e)
+		return
+	}
 	permissions, e := cr.permissionDAO.GetByPath(path)
 	if e != nil {
 		_ = c.Error(e)
@@ -38,7 +42,11 @@ func (cr *configRoute) getPathPermissions(c *gin.Context) {
 }
 
 func (cr *configRoute) savePathPermissions(c *gin.Context) {
-	path := utils.CleanPath(c.Param("path"))
+	path, e := getQueryPath(c, "path")
+	if e != nil {
+		_ = c.Error(e)
+		return
+	}
 	permissions := make([]types.PathPermission, 0)
 	if e := c.Bind(&permissions); e != nil {
 		_ = c.Error(e)
@@ -65,7 +73,11 @@ func (cr *configRoute) getAllPathMeta(c *gin.Context) {
 }
 
 func (cr *configRoute) savePathMeta(c *gin.Context) {
-	path := utils.CleanPath(c.Param("path"))
+	path, e := getQueryPath(c, "path")
+	if e != nil {
+		_ = c.Error(e)
+		return
+	}
 	data := types.PathMeta{}
 	if e := c.Bind(&data); e != nil {
 		_ = c.Error(e)
@@ -79,7 +91,11 @@ func (cr *configRoute) savePathMeta(c *gin.Context) {
 }
 
 func (cr *configRoute) deletePathMeta(c *gin.Context) {
-	path := utils.CleanPath(c.Param("path"))
+	path, e := getQueryPath(c, "path")
+	if e != nil {
+		_ = c.Error(e)
+		return
+	}
 	if e := cr.pathMetaDAO.Delete(path); e != nil {
 		_ = c.Error(e)
 		return
@@ -88,7 +104,11 @@ func (cr *configRoute) deletePathMeta(c *gin.Context) {
 
 func (cr *configRoute) savePathMounts(c *gin.Context) {
 	principal := GetPrincipal(c)
-	to := utils.CleanPath(c.Param("to"))
+	to, e := getQueryPath(c, "path")
+	if e != nil {
+		_ = c.Error(e)
+		return
+	}
 	src := make([]mountSource, 0)
 	if e := c.Bind(&src); e != nil {
 		_ = c.Error(e)

--- a/server/api_admin_misc.go
+++ b/server/api_admin_misc.go
@@ -4,7 +4,6 @@ import (
 	err "go-drive/common/errors"
 	"go-drive/common/registry"
 	"go-drive/common/types"
-	"go-drive/common/utils"
 	"go-drive/drive"
 	"go-drive/server/search"
 	"go-drive/storage"
@@ -23,7 +22,11 @@ type miscRoute struct {
 }
 
 func (mr *miscRoute) updateSearcherIndexes(c *gin.Context) {
-	root := utils.CleanPath(c.Param("path"))
+	root, e := getQueryPath(c, "path")
+	if e != nil {
+		_ = c.Error(e)
+		return
+	}
 	t, e := mr.search.TriggerIndexAll(root, true)
 	if e != nil {
 		_ = c.Error(e)

--- a/server/api_common.go
+++ b/server/api_common.go
@@ -29,9 +29,9 @@ func InitCommonRoutes(
 
 	authR := r.Group("/", TokenAuth(tokenStore))
 	// get task
-	authR.GET("/task/:id", cr.getTask)
+	authR.GET("/tasks/:id", cr.getTask)
 	// cancel and delete task
-	authR.DELETE("/task/:id", cr.cancelAndDeleteTask)
+	authR.DELETE("/tasks/:id", cr.cancelAndDeleteTask)
 
 	authAdmin := authR.Group("/", AdminGroupRequired())
 	// get tasks

--- a/server/api_drive.go
+++ b/server/api_drive.go
@@ -55,42 +55,42 @@ func InitDriveRoutes(
 	signatureAuthRoute := router.Group("/", SignatureAuth(signer, userDAO, true))
 
 	// get file content
-	signatureAuthRoute.HEAD("/content/*path", dr._getDrive, dr.getContent)
-	signatureAuthRoute.GET("/content/*path", dr._getDrive, dr.getContent)
-	signatureAuthRoute.GET("/thumbnail/*path", dr._getDrive, dr.getThumbnail)
+	signatureAuthRoute.HEAD("/download", dr._getDrive, dr.getContent)
+	signatureAuthRoute.GET("/download", dr._getDrive, dr.getContent)
+	signatureAuthRoute.GET("/thumbnail", dr._getDrive, dr.getThumbnail)
 
 	tokenAuth := TokenAuth(tokenStore)
 	r := router.Group("/", tokenAuth)
 
-	router.POST("/zip", TokenAuthWithPostParams(tokenStore), dr._getDrive, dr.zipDownload)
+	router.POST("/archive", TokenAuthWithPostParams(tokenStore), dr._getDrive, dr.zipDownload)
 
 	// list entries/drives
-	router.GET("/entries/*path", SignatureAuth(signer, userDAO, false), tokenAuth, dr._getDrive, dr.list)
+	router.GET("/list", SignatureAuth(signer, userDAO, false), tokenAuth, dr._getDrive, dr.list)
 
 	// get entry info
-	r.GET("/entry/*path", dr._getDrive, dr.get)
+	r.GET("/stat", dr._getDrive, dr.get)
 	// mkdir
-	r.POST("/mkdir/*path", dr._getDrive, dr.makeDir)
+	r.POST("/mkdir", dr._getDrive, dr.makeDir)
 	// copy file
 	r.POST("/copy", dr._getDrive, dr.copyEntry)
 	// move file
 	r.POST("/move", dr._getDrive, dr.move)
 	// deleteEntry entry
-	r.DELETE("/entry/*path", dr._getDrive, dr.deleteEntry)
+	r.POST("/delete", dr._getDrive, dr.deleteEntry)
 	// get upload config
-	r.POST("/upload/*path", dr._getDrive, dr.upload)
+	r.POST("/prepare-upload", dr._getDrive, dr.upload)
 	// write file
-	r.PUT("/content/*path", dr._getDrive, dr.writeContent)
-	// chunk upload request
-	r.POST("/chunk", dr.chunkUploadRequest)
-	// chunk upload
-	r.PUT("/chunk/:id/:seq", dr.chunkUpload)
-	// chunk upload complete
-	r.POST("/chunk-content/*path", dr._getDrive, dr.chunkUploadComplete)
+	r.POST("/write", dr._getDrive, dr.writeContent)
+	// create chunk upload
+	r.POST("/chunk-uploads", dr.createChunkUpload)
+	// upload chunk
+	r.PUT("/chunk-uploads/:id/chunks/:seq", dr.uploadChunk)
+	// complete chunk upload
+	r.POST("/chunk-uploads/:id/completion", dr._getDrive, dr.completeChunkUpload)
 	// delete chunk upload
-	r.DELETE("/chunk/:id", dr.deleteChunkUpload)
+	r.DELETE("/chunk-uploads/:id", dr.deleteChunkUpload)
 	// search
-	r.GET("/search/*path", dr.search)
+	r.GET("/search", dr.search)
 
 	return nil
 }
@@ -129,7 +129,11 @@ func (dr *driveRoute) _getDrive(c *gin.Context) {
 }
 
 func (dr *driveRoute) list(c *gin.Context) {
-	path := utils.CleanPath(c.Param("path"))
+	path, e := getQueryPath(c, "path")
+	if e != nil {
+		_ = c.Error(e)
+		return
+	}
 	d := c.MustGet("drive").(types.IDrive)
 
 	entry, e := d.Get(c.Request.Context(), path)
@@ -152,7 +156,11 @@ func (dr *driveRoute) list(c *gin.Context) {
 }
 
 func (dr *driveRoute) get(c *gin.Context) {
-	path := utils.CleanPath(c.Param("path"))
+	path, e := getQueryPath(c, "path")
+	if e != nil {
+		_ = c.Error(e)
+		return
+	}
 	d := c.MustGet("drive").(types.IDrive)
 
 	entry, e := d.Get(c.Request.Context(), path)
@@ -164,7 +172,11 @@ func (dr *driveRoute) get(c *gin.Context) {
 }
 
 func (dr *driveRoute) makeDir(c *gin.Context) {
-	path := utils.CleanPath(c.Param("path"))
+	path, e := getQueryPath(c, "path")
+	if e != nil {
+		_ = c.Error(e)
+		return
+	}
 	d := c.MustGet("drive").(types.IDrive)
 
 	entry, e := d.MakeDir(c.Request.Context(), path)
@@ -178,13 +190,21 @@ func (dr *driveRoute) makeDir(c *gin.Context) {
 func (dr *driveRoute) copyEntry(c *gin.Context) {
 	drive_ := c.MustGet("drive").(types.IDrive)
 
-	from := utils.CleanPath(c.Query("from"))
+	from, e := getQueryPath(c, "from")
+	if e != nil {
+		_ = c.Error(e)
+		return
+	}
 	fromEntry, e := drive_.Get(c.Request.Context(), from)
 	if e != nil {
 		_ = c.Error(e)
 		return
 	}
-	to := utils.CleanPath(c.Query("to"))
+	to, e := getQueryPath(c, "to")
+	if e != nil {
+		_ = c.Error(e)
+		return
+	}
 	if e := checkCopyOrMove(from, to); e != nil {
 		_ = c.Error(e)
 		return
@@ -209,13 +229,21 @@ func (dr *driveRoute) copyEntry(c *gin.Context) {
 func (dr *driveRoute) move(c *gin.Context) {
 	drive_ := c.MustGet("drive").(types.IDrive)
 
-	from := utils.CleanPath(c.Query("from"))
+	from, e := getQueryPath(c, "from")
+	if e != nil {
+		_ = c.Error(e)
+		return
+	}
 	fromEntry, e := drive_.Get(c.Request.Context(), from)
 	if e != nil {
 		_ = c.Error(e)
 		return
 	}
-	to := utils.CleanPath(c.Query("to"))
+	to, e := getQueryPath(c, "to")
+	if e != nil {
+		_ = c.Error(e)
+		return
+	}
 	if e := checkCopyOrMove(from, to); e != nil {
 		_ = c.Error(e)
 		return
@@ -248,7 +276,11 @@ func checkCopyOrMove(from, to string) error {
 }
 
 func (dr *driveRoute) deleteEntry(c *gin.Context) {
-	path := utils.CleanPath(c.Param("path"))
+	path, e := getQueryPath(c, "path")
+	if e != nil {
+		_ = c.Error(e)
+		return
+	}
 	d := c.MustGet("drive").(types.IDrive)
 
 	t, e := dr.runner.ExecuteAndWait(func(ctx types.TaskCtx) (any, error) {
@@ -262,7 +294,11 @@ func (dr *driveRoute) deleteEntry(c *gin.Context) {
 }
 
 func (dr *driveRoute) upload(c *gin.Context) {
-	path := utils.CleanPath(c.Param("path"))
+	path, e := getQueryPath(c, "path")
+	if e != nil {
+		_ = c.Error(e)
+		return
+	}
 	override := utils.ToBool(c.Query("override"))
 	size := utils.ToInt64(c.Query("size"), -1)
 	request := make(types.SM, 0)
@@ -282,7 +318,11 @@ func (dr *driveRoute) upload(c *gin.Context) {
 }
 
 func (dr *driveRoute) getContent(c *gin.Context) {
-	path := utils.CleanPath(c.Param("path"))
+	path, e := getQueryPath(c, "path")
+	if e != nil {
+		_ = c.Error(e)
+		return
+	}
 	d := c.MustGet("drive").(types.IDrive)
 	file, e := d.Get(c.Request.Context(), path)
 	if e != nil {
@@ -384,7 +424,11 @@ func (dr *driveRoute) zipDownload(c *gin.Context) {
 }
 
 func (dr *driveRoute) getThumbnail(c *gin.Context) {
-	path := utils.CleanPath(c.Param("path"))
+	path, e := getQueryPath(c, "path")
+	if e != nil {
+		_ = c.Error(e)
+		return
+	}
 	d := c.MustGet("drive").(types.IDrive)
 
 	entry, e := d.Get(c.Request.Context(), path)
@@ -412,7 +456,11 @@ func (dr *driveRoute) getThumbnail(c *gin.Context) {
 }
 
 func (dr *driveRoute) writeContent(c *gin.Context) {
-	path := utils.CleanPath(c.Param("path"))
+	path, e := getQueryPath(c, "path")
+	if e != nil {
+		_ = c.Error(e)
+		return
+	}
 	d := c.MustGet("drive").(types.IDrive)
 
 	principal := GetPrincipal(c)
@@ -441,14 +489,22 @@ func (dr *driveRoute) writeContent(c *gin.Context) {
 	SetResult(c, t)
 }
 
-func (dr *driveRoute) chunkUploadRequest(c *gin.Context) {
-	size := utils.ToInt64(c.Query("size"), -1)
-	chunkSize := utils.ToInt64(c.Query("chunkSize"), -1)
-	if size <= 0 || chunkSize <= 0 {
+type createChunkUploadRequest struct {
+	Size      int64 `json:"size"`
+	ChunkSize int64 `json:"chunkSize"`
+}
+
+func (dr *driveRoute) createChunkUpload(c *gin.Context) {
+	request := createChunkUploadRequest{}
+	if e := c.ShouldBindJSON(&request); e != nil {
+		_ = c.Error(err.NewBadRequestError(e.Error()))
+		return
+	}
+	if request.Size <= 0 || request.ChunkSize <= 0 {
 		_ = c.Error(err.NewBadRequestError(i18n.T("api.drive.invalid_size_or_chunk_size")))
 		return
 	}
-	upload, e := dr.chunkUploader.CreateUpload(size, chunkSize)
+	upload, e := dr.chunkUploader.CreateUpload(request.Size, request.ChunkSize)
 	if e != nil {
 		_ = c.Error(e)
 		return
@@ -456,7 +512,7 @@ func (dr *driveRoute) chunkUploadRequest(c *gin.Context) {
 	SetResult(c, upload)
 }
 
-func (dr *driveRoute) chunkUpload(c *gin.Context) {
+func (dr *driveRoute) uploadChunk(c *gin.Context) {
 	id := c.Param("id")
 	seq, e := strconv.Atoi(c.Param("seq"))
 	if e != nil {
@@ -468,13 +524,22 @@ func (dr *driveRoute) chunkUpload(c *gin.Context) {
 	}
 }
 
-func (dr *driveRoute) chunkUploadComplete(c *gin.Context) {
+type completeChunkUploadRequest struct {
+	Path     string `json:"path"`
+	Override bool   `json:"override"`
+}
+
+func (dr *driveRoute) completeChunkUpload(c *gin.Context) {
 	d := c.MustGet("drive").(types.IDrive)
 
+	request := completeChunkUploadRequest{}
+	if e := c.ShouldBindJSON(&request); e != nil {
+		_ = c.Error(err.NewBadRequestError(e.Error()))
+		return
+	}
 	principal := GetPrincipal(c)
-	override := utils.ToBool(c.Query("override"))
-	path := utils.CleanPath(c.Param("path"))
-	id := c.Query("id")
+	path := utils.CleanPath(request.Path)
+	id := c.Param("id")
 	t, e := dr.runner.ExecuteAndWait(func(ctx types.TaskCtx) (any, error) {
 		file, e := dr.chunkUploader.CompleteUpload(id, ctx)
 		if e != nil {
@@ -487,7 +552,7 @@ func (dr *driveRoute) chunkUploadComplete(c *gin.Context) {
 		}
 		ctx.Progress(0, true)
 		tempFile := utils.NewTempFile(file)
-		entry, e := d.Save(ctx, path, stat.Size(), override, tempFile)
+		entry, e := d.Save(ctx, path, stat.Size(), request.Override, tempFile)
 		if e != nil {
 			_ = tempFile.Close()
 			return nil, e
@@ -511,7 +576,11 @@ func (dr *driveRoute) deleteChunkUpload(c *gin.Context) {
 }
 
 func (dr *driveRoute) search(c *gin.Context) {
-	root := utils.CleanPath(c.Param("path"))
+	root, e := getQueryPath(c, "path")
+	if e != nil {
+		_ = c.Error(e)
+		return
+	}
 	query := c.Query("q")
 	next := utils.ToInt(c.Query("next"), 0)
 

--- a/server/api_routes_test.go
+++ b/server/api_routes_test.go
@@ -1,0 +1,294 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"go-drive/common"
+	"go-drive/common/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestSignatureAuthBindsQueryPath(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	signer := utils.NewSigner()
+	signature := MakeSignature(signer, "a/b", "", time.Minute)
+
+	tests := []struct {
+		name   string
+		target string
+		called bool
+	}{
+		{
+			name:   "valid canonical path",
+			target: "/download?path=a%2F.%2Fb&_k=" + signature,
+			called: true,
+		},
+		{
+			name:   "tampered path",
+			target: "/download?path=a%2Fc&_k=" + signature,
+		},
+		{
+			name:   "missing path",
+			target: "/download?_k=" + signature,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			called := false
+			router := gin.New()
+			router.GET("/download", SignatureAuth(signer, nil, true), func(*gin.Context) {
+				called = true
+			})
+			router.ServeHTTP(
+				httptest.NewRecorder(),
+				httptest.NewRequest(http.MethodGet, tt.target, nil),
+			)
+			if called != tt.called {
+				t.Fatalf("handler called = %v, want %v", called, tt.called)
+			}
+		})
+	}
+}
+
+func TestCreateChunkUploadAcceptsJSONBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(
+		http.MethodPost,
+		"/chunk-uploads",
+		strings.NewReader(`{"size":10485760,"chunkSize":5242880}`),
+	)
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	dr := driveRoute{chunkUploader: &ChunkUploader{dir: t.TempDir()}}
+	dr.createChunkUpload(c)
+
+	if len(c.Errors) != 0 {
+		t.Fatalf("createChunkUpload() errors = %v", c.Errors)
+	}
+	result, ok := GetResult(c)
+	if !ok {
+		t.Fatal("createChunkUpload() did not set a result")
+	}
+	upload, ok := result.(ChunkUpload)
+	if !ok {
+		t.Fatalf("createChunkUpload() result type = %T, want ChunkUpload", result)
+	}
+	if upload.Size != 10485760 || upload.ChunkSize != 5242880 || upload.Chunks != 2 {
+		t.Fatalf("createChunkUpload() result = %+v", upload)
+	}
+}
+
+func TestCommonRoutesUsePluralTaskResource(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	if e := InitCommonRoutes(nil, router, nil, nil, nil); e != nil {
+		t.Fatalf("InitCommonRoutes() error = %v", e)
+	}
+
+	assertRegisteredRoutes(t, router,
+		"GET /tasks",
+		"GET /tasks/:id",
+		"DELETE /tasks/:id",
+	)
+	assertRoutesNotRegistered(t, router,
+		"GET /task/:id",
+		"DELETE /task/:id",
+	)
+}
+
+func TestAdminRoutesUseNormalizedResources(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	if e := InitAdminRoutes(
+		router, nil, common.Config{}, nil, nil, nil, nil, nil, nil, nil,
+		nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+	); e != nil {
+		t.Fatalf("InitAdminRoutes() error = %v", e)
+	}
+
+	if got := len(router.Routes()); got != 51 {
+		t.Fatalf("registered admin route count = %d, want 51", got)
+	}
+	assertRegisteredRoutes(t, router,
+		"GET /admin/users",
+		"POST /admin/users",
+		"GET /admin/users/:username",
+		"PUT /admin/users/:username",
+		"DELETE /admin/users/:username",
+		"GET /admin/groups",
+		"POST /admin/groups",
+		"GET /admin/groups/:name",
+		"PUT /admin/groups/:name",
+		"DELETE /admin/groups/:name",
+		"GET /admin/drives",
+		"POST /admin/drives",
+		"PUT /admin/drives/:name",
+		"DELETE /admin/drives/:name",
+		"POST /admin/drives/:name/init-config",
+		"POST /admin/drives/:name/init",
+		"POST /admin/drives/reload",
+		"GET /admin/path-permissions",
+		"PUT /admin/path-permissions",
+		"GET /admin/path-metadata",
+		"PUT /admin/path-metadata",
+		"DELETE /admin/path-metadata",
+		"PUT /admin/path-mounts",
+		"PUT /admin/search-indexes",
+		"POST /admin/maintenance/path-rules/cleanup",
+		"DELETE /admin/drives/:name/cache",
+		"GET /admin/drive-scripts/available",
+		"GET /admin/drive-scripts/installed",
+		"PUT /admin/drive-scripts/:name",
+		"DELETE /admin/drive-scripts/:name",
+		"GET /admin/drive-scripts/:name/content",
+		"PUT /admin/drive-scripts/:name/content",
+		"GET /admin/job-definitions",
+		"GET /admin/job-executions",
+		"POST /admin/job-executions",
+		"POST /admin/job-executions/:id/cancel",
+		"DELETE /admin/job-executions/:id",
+		"DELETE /admin/job-executions",
+		"POST /admin/job-script-evaluations",
+		"GET /admin/file-buckets",
+		"POST /admin/file-buckets",
+		"PUT /admin/file-buckets/:name",
+		"DELETE /admin/file-buckets/:name",
+	)
+	assertRoutesNotRegistered(t, router,
+		"GET /admin/user/:username",
+		"POST /admin/drive",
+		"GET /admin/path-meta",
+		"POST /admin/mount/*to",
+		"GET /admin/path-permissions/*path",
+		"PUT /admin/path-permissions/*path",
+		"PUT /admin/path-metadata/*path",
+		"DELETE /admin/path-metadata/*path",
+		"PUT /admin/path-mounts/*path",
+		"PUT /admin/search-indexes/*path",
+		"GET /admin/jobs/executions",
+		"POST /admin/scripts/install/:name",
+		"POST /admin/file-bucket",
+	)
+}
+
+func TestDriveRoutesUseRPCOperations(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	if e := InitDriveRoutes(
+		router, nil, nil, common.Config{}, nil, nil, nil, nil, nil, nil, nil, nil,
+	); e != nil {
+		t.Fatalf("InitDriveRoutes() error = %v", e)
+	}
+
+	if got := len(router.Routes()); got != 19 {
+		t.Fatalf("registered drive route count = %d, want 19", got)
+	}
+	assertRegisteredRoutes(t, router,
+		"GET /stat",
+		"GET /list",
+		"POST /mkdir",
+		"POST /copy",
+		"POST /move",
+		"POST /delete",
+		"POST /prepare-upload",
+		"POST /write",
+		"GET /download",
+		"HEAD /download",
+		"GET /thumbnail",
+		"GET /search",
+		"POST /archive",
+		"POST /chunk-uploads",
+		"PUT /chunk-uploads/:id/chunks/:seq",
+		"POST /chunk-uploads/:id/completion",
+		"DELETE /chunk-uploads/:id",
+	)
+	assertRoutesNotRegistered(t, router,
+		"GET /entry/*path",
+		"DELETE /entry/*path",
+		"GET /entries/*path",
+		"POST /mkdir/*path",
+		"POST /upload/*path",
+		"GET /content/*path",
+		"PUT /content/*path",
+		"GET /thumbnail/*path",
+		"GET /search/*path",
+		"POST /zip",
+		"POST /chunk",
+		"PUT /chunk/:id/:seq",
+		"POST /chunk-content/*path",
+		"DELETE /chunk/:id",
+	)
+}
+
+func TestGetQueryPathRequiresParameterAndAllowsRoot(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("missing", func(t *testing.T) {
+		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		c.Request = httptest.NewRequest(http.MethodGet, "/stat", nil)
+		if _, e := getQueryPath(c, "path"); e == nil {
+			t.Fatal("getQueryPath() error = nil, want missing parameter error")
+		}
+	})
+
+	t.Run("root", func(t *testing.T) {
+		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		c.Request = httptest.NewRequest(http.MethodGet, "/stat?path=", nil)
+		path, e := getQueryPath(c, "path")
+		if e != nil {
+			t.Fatalf("getQueryPath() error = %v", e)
+		}
+		if path != "" {
+			t.Fatalf("getQueryPath() = %q, want root path", path)
+		}
+	})
+
+	t.Run("clean", func(t *testing.T) {
+		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		c.Request = httptest.NewRequest(http.MethodGet, "/stat?path=a%2F.%2Fb%2F..%2Fc", nil)
+		path, e := getQueryPath(c, "path")
+		if e != nil {
+			t.Fatalf("getQueryPath() error = %v", e)
+		}
+		if path != "a/c" {
+			t.Fatalf("getQueryPath() = %q, want %q", path, "a/c")
+		}
+	})
+}
+
+func assertRegisteredRoutes(t *testing.T, router *gin.Engine, expected ...string) {
+	t.Helper()
+	routes := registeredRouteSet(router)
+	for _, route := range expected {
+		if _, ok := routes[route]; !ok {
+			t.Errorf("route %q is not registered", route)
+		}
+	}
+}
+
+func assertRoutesNotRegistered(t *testing.T, router *gin.Engine, unexpected ...string) {
+	t.Helper()
+	routes := registeredRouteSet(router)
+	for _, route := range unexpected {
+		if _, ok := routes[route]; ok {
+			t.Errorf("legacy route %q is still registered", route)
+		}
+	}
+}
+
+func registeredRouteSet(router *gin.Engine) map[string]struct{} {
+	result := make(map[string]struct{})
+	for _, route := range router.Routes() {
+		result[route.Method+" "+route.Path] = struct{}{}
+	}
+	return result
+}

--- a/server/thumbnail/index.go
+++ b/server/thumbnail/index.go
@@ -163,15 +163,11 @@ func (m *Maker) createThumbnailEntry(entry types.IEntry) (ThumbnailEntry, error)
 	externalURL := m.apiPath
 
 	if entry.Type().IsDir() {
-		externalURL += "/entries/"
+		externalURL += "/list"
 	} else {
-		externalURL += "/content/"
+		externalURL += "/download"
 	}
-	pathURL, e := url.Parse(entry.Path())
-	if e != nil {
-		return nil, e
-	}
-	externalURL += pathURL.String()
+	query := url.Values{"path": []string{entry.Path()}}
 
 	ako, ok := entry.Meta().Props["accessKey"]
 	ak := ""
@@ -181,8 +177,9 @@ func (m *Maker) createThumbnailEntry(entry types.IEntry) (ThumbnailEntry, error)
 		}
 	}
 	if ak != "" {
-		externalURL += "?" + common.SignatureQueryKey + "=" + url.QueryEscape(ak)
+		query.Set(common.SignatureQueryKey, ak)
 	}
+	externalURL += "?" + query.Encode()
 
 	return &thumbnailEntry{
 		IEntry:           entry,

--- a/server/thumbnail/shell.go
+++ b/server/thumbnail/shell.go
@@ -42,7 +42,8 @@ func init() {
 //
 // GO_DRIVE_ENTRY_MOD_TIME: timestamp, modTime of this entry
 //
-// GO_DRIVE_ENTRY_URL: URL of the file content or folder children (e.g. /content/a/a.txt or /entries/a)
+// GO_DRIVE_ENTRY_URL: URL of the file content or folder children
+// (e.g. /download?path=a/a.txt or /list?path=a)
 type shellThumbnailTypeHandler struct {
 	command string
 	args    []string

--- a/server/utils.go
+++ b/server/utils.go
@@ -61,7 +61,12 @@ func SignatureAuth(signer *utils.Signer, userDAO *storage.UserDAO, signatureRequ
 
 		var username string
 
-		path := utils.CleanPath(c.Param("path"))
+		path, e := getQueryPath(c, "path")
+		if e != nil {
+			_ = c.Error(e)
+			c.Abort()
+			return
+		}
 
 		parts := strings.Split(signature, ".")
 		signature = parts[0]
@@ -97,6 +102,14 @@ func SignatureAuth(signer *utils.Signer, userDAO *storage.UserDAO, signatureRequ
 		SetPrincipal(c, principal)
 		c.Next()
 	}
+}
+
+func getQueryPath(c *gin.Context, key string) (string, error) {
+	path, exists := c.GetQuery(key)
+	if !exists {
+		return "", err.NewBadRequestError("missing query parameter: " + key)
+	}
+	return utils.CleanPath(path), nil
 }
 
 func MakeSignature(signer *utils.Signer, path, username string, ttl time.Duration) string {

--- a/web/src/api/admin.ts
+++ b/web/src/api/admin.ts
@@ -24,19 +24,19 @@ export function getUsers() {
 }
 
 export function getUser(username: string) {
-  return http.get<User>(`/admin/user/${username}`)
+  return http.get<User>(`/admin/users/${username}`)
 }
 
 export function createUser(user: Partial<User>) {
-  return http.post<User>('/admin/user', user)
+  return http.post<User>('/admin/users', user)
 }
 
 export function updateUser(username: string, user: Partial<User>) {
-  return http.put<void>(`/admin/user/${username}`, user)
+  return http.put<void>(`/admin/users/${username}`, user)
 }
 
 export function deleteUser(username: string) {
-  return http.delete<void>(`/admin/user/${username}`)
+  return http.delete<void>(`/admin/users/${username}`)
 }
 
 export function getGroups() {
@@ -44,19 +44,19 @@ export function getGroups() {
 }
 
 export function getGroup(name: string) {
-  return http.get<Group>(`/admin/group/${name}`)
+  return http.get<Group>(`/admin/groups/${name}`)
 }
 
 export function createGroup(group: Partial<Group>) {
-  return http.post<Group>('/admin/group', group)
+  return http.post<Group>('/admin/groups', group)
 }
 
 export function updateGroup(name: string, group: Partial<Group>) {
-  return http.put<void>(`/admin/group/${name}`, group)
+  return http.put<void>(`/admin/groups/${name}`, group)
 }
 
 export function deleteGroup(name: string) {
-  return http.delete<void>(`/admin/group/${name}`)
+  return http.delete<void>(`/admin/groups/${name}`)
 }
 
 export function getDriveFactories() {
@@ -68,23 +68,23 @@ export function getDrives() {
 }
 
 export function createDrive(drive: Partial<Drive>) {
-  return http.post<Drive>('/admin/drive', drive)
+  return http.post<Drive>('/admin/drives', drive)
 }
 
 export function updateDrive(name: string, drive: Partial<Drive>) {
-  return http.put<void>(`/admin/drive/${name}`, drive)
+  return http.put<void>(`/admin/drives/${name}`, drive)
 }
 
 export function deleteDrive(name: string) {
-  return http.delete<void>(`/admin/drive/${name}`)
+  return http.delete<void>(`/admin/drives/${name}`)
 }
 
 export function getDriveInitConfig(name: string) {
-  return http.post<DriveInitConfig>(`/admin/drive/${name}/init-config`)
+  return http.post<DriveInitConfig>(`/admin/drives/${name}/init-config`)
 }
 
 export function initDrive(name: string, data: O<string>) {
-  return http.post(`/admin/drive/${name}/init`, data)
+  return http.post(`/admin/drives/${name}/init`, data)
 }
 
 export function reloadDrives() {
@@ -92,36 +92,41 @@ export function reloadDrives() {
 }
 
 export function getPermissions(path: string) {
-  return http.get<PathPermission[]>(`/admin/path-permissions/${path}`)
+  return http.get<PathPermission[]>('/admin/path-permissions', {
+    params: { path },
+  })
 }
 
 export function savePermissions(path: string, permissions: O[]) {
-  return http.put<void>(`/admin/path-permissions/${path}`, permissions)
+  return http.put<void>('/admin/path-permissions', permissions, {
+    params: { path },
+  })
 }
 
 export function getAllPathMeta() {
-  return http.get<PathMeta[]>('/admin/path-meta')
+  return http.get<PathMeta[]>('/admin/path-metadata')
 }
 
 export function savePathMeta(path: string, data: Partial<PathMeta>) {
-  return http.post<void>(`/admin/path-meta/${path}`, data)
+  return http.put<void>('/admin/path-metadata', data, { params: { path } })
 }
 
 export function deletePathMeta(path: string) {
-  return http.delete<void>(`/admin/path-meta/${path}`)
+  return http.delete<void>('/admin/path-metadata', { params: { path } })
 }
 
 export function mountPaths(pathTo: string, mounts: PathMountSource[]) {
-  const encodedPath = pathTo.split('/').map(encodeURIComponent).join('/')
-  return http.post<void>(`/admin/mount/${encodedPath}`, mounts)
+  return http.put<void>('/admin/path-mounts', mounts, {
+    params: { path: pathTo },
+  })
 }
 
 export function cleanPermissionsAndMounts() {
-  return http.post<number>('/admin/clean-permissions-mounts')
+  return http.post<number>('/admin/maintenance/path-rules/cleanup')
 }
 
 export function cleanDriveCache(name: string) {
-  return http.delete<void>(`/admin/drive-cache/${name}`)
+  return http.delete<void>(`/admin/drives/${name}/cache`)
 }
 
 export function loadStats() {
@@ -129,7 +134,9 @@ export function loadStats() {
 }
 
 export function searchIndex(path: string) {
-  return http.post<Task<void>>(`/admin/search/index/${path}`)
+  return http.put<Task<void>>('/admin/search-indexes', null, {
+    params: { path },
+  })
 }
 
 export function setOptions(options: O<string>) {
@@ -143,7 +150,7 @@ export function getOptions(...keys: string[]) {
 }
 
 export function getJobDefinitions() {
-  return http.get<JobDefinitions>('/admin/jobs/definitions')
+  return http.get<JobDefinitions>('/admin/job-definitions')
 }
 
 export function getJobs() {
@@ -163,14 +170,14 @@ export function deleteJob(id: number) {
 }
 
 export function getJobExecutions(jobId: number) {
-  return http.get<JobExecution[]>('/admin/jobs/executions', {
+  return http.get<JobExecution[]>('/admin/job-executions', {
     params: { jobId },
   })
 }
 
 export function executeJobSync(jobId: number) {
   return streamHttp.post<StreamHttpResponse<Task>>(
-    '/admin/jobs/execution',
+    '/admin/job-executions',
     null,
     { params: { jobId } }
   )
@@ -178,49 +185,47 @@ export function executeJobSync(jobId: number) {
 
 export function jobScriptEvalSync(code: string) {
   return streamHttp.post<StreamHttpResponse<Task>>(
-    '/admin/jobs/script-eval',
+    '/admin/job-script-evaluations',
     code,
     { headers: { 'content-type': 'text/plain' } }
   )
 }
 
 export function cancelJobExecution(id: number) {
-  return http.put<void>(`/admin/jobs/execution/${id}/cancel`)
+  return http.post<void>(`/admin/job-executions/${id}/cancel`)
 }
 
 export function deleteJobExecution(id: number) {
-  return http.delete<void>(`/admin/jobs/execution/${id}`)
+  return http.delete<void>(`/admin/job-executions/${id}`)
 }
 
 export function deleteJobExecutions(jobId: number) {
-  return http.delete<void>('/admin/jobs/execution', {
+  return http.delete<void>('/admin/job-executions', {
     params: { jobId },
   })
 }
 
 export function listAvailableDriveScripts(force?: boolean) {
-  return http.get<AvailableDriveScript[]>('/admin/scripts/available', {
+  return http.get<AvailableDriveScript[]>('/admin/drive-scripts/available', {
     params: { force },
   })
 }
 
 export function listInstalledDriveScripts() {
-  return http.get<InstalledDriveScript[]>('/admin/scripts/installed')
+  return http.get<InstalledDriveScript[]>('/admin/drive-scripts/installed')
 }
 
 export function installDriveScript(name: string) {
-  return http.post<void>(`/admin/scripts/install/${encodeURIComponent(name)}`)
+  return http.put<void>(`/admin/drive-scripts/${encodeURIComponent(name)}`)
 }
 
 export function uninstallDriveScript(name: string) {
-  return http.delete<void>(
-    `/admin/scripts/uninstall/${encodeURIComponent(name)}`
-  )
+  return http.delete<void>(`/admin/drive-scripts/${encodeURIComponent(name)}`)
 }
 
 export function getDriveScriptContent(name: string) {
   return http.get<DriveScriptContent>(
-    `/admin/scripts/content/${encodeURIComponent(name)}`
+    `/admin/drive-scripts/${encodeURIComponent(name)}/content`
   )
 }
 
@@ -228,7 +233,10 @@ export function saveDriveScriptContent(
   name: string,
   content: Partial<DriveScriptContent>
 ) {
-  return http.put(`/admin/scripts/content/${encodeURIComponent(name)}`, content)
+  return http.put(
+    `/admin/drive-scripts/${encodeURIComponent(name)}/content`,
+    content
+  )
 }
 
 export function getAllFileBuckets() {
@@ -236,13 +244,13 @@ export function getAllFileBuckets() {
 }
 
 export function createFileBucket(bucket: Partial<FileBucket>) {
-  return http.post<FileBucket>('/admin/file-bucket', bucket)
+  return http.post<FileBucket>('/admin/file-buckets', bucket)
 }
 
 export function updateFileBucket(name: string, bucket: Partial<FileBucket>) {
-  return http.put<void>(`/admin/file-bucket/${name}`, bucket)
+  return http.put<void>(`/admin/file-buckets/${name}`, bucket)
 }
 
 export function deleteFileBucket(name: string) {
-  return http.delete<void>(`/admin/file-bucket/${name}`)
+  return http.delete<void>(`/admin/file-buckets/${name}`)
 }

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -30,25 +30,27 @@ export interface FileURLParams {
 }
 
 export function listEntries(path: string) {
-  return http.get<Entry[]>(`/entries/${path}`, {
+  return http.get<Entry[]>('/list', {
     headers: pathPasswordHeaders(path),
+    params: { path },
   })
 }
 
 export function getEntry(path: string) {
-  return http.get<Entry>(`/entry/${path}`, {
+  return http.get<Entry>('/stat', {
     headers: pathPasswordHeaders(path),
+    params: { path },
   })
 }
 
 export function searchEntries(path: string, q: string, next?: number) {
-  return http.get<SearchResult>(`/search/${path}`, {
-    params: { q, next },
+  return http.get<SearchResult>('/search', {
+    params: { path, q, next },
   })
 }
 
 function _fileUrl(path: string, meta: EntryMeta, params?: FileURLParams) {
-  const query = {} as O<any>
+  const query = { path } as O<any>
   if (meta?.accessKey) {
     query[ACCESS_KEY] = meta.accessKey
   }
@@ -72,11 +74,11 @@ function _fileUrl(path: string, meta: EntryMeta, params?: FileURLParams) {
     }
   }
   if (params?.noCache) query.r = Math.random()
-  return buildURL(`/content/${path}`, query)!
+  return buildURL('/download', query)!
 }
 
 export function zipUrl() {
-  return `${API_PATH}/zip`
+  return `${API_PATH}/archive`
 }
 
 export function fileUrl(path: string, meta: EntryMeta, params?: FileURLParams) {
@@ -84,11 +86,11 @@ export function fileUrl(path: string, meta: EntryMeta, params?: FileURLParams) {
 }
 
 export function fileThumbnail(path: string, meta: EntryMeta) {
-  const query = {} as O<any>
+  const query = { path } as O<any>
   if (meta?.accessKey) {
     query[ACCESS_KEY] = meta.accessKey
   }
-  return buildURL(`${API_PATH}/thumbnail/${path}`, query)!
+  return buildURL(`${API_PATH}/thumbnail`, query)!
 }
 
 const textHttp = createHttp({
@@ -111,11 +113,11 @@ export function getContent(
 }
 
 export function makeDir(path: string) {
-  return http.post<Entry>(`/mkdir/${path}`)
+  return http.post<Entry>('/mkdir', null, { params: { path } })
 }
 
 export function deleteEntry(path: string) {
-  return http.delete<Task<void>>(`/entry/${path}`)
+  return http.post<Task<void>>('/delete', null, { params: { path } })
 }
 
 export function copyEntry(from: string, to: string, override?: boolean) {
@@ -137,11 +139,11 @@ export function getTasks<T>(group: string) {
 }
 
 export function getTask<T>(id: string) {
-  return http.get<Task<T>>(`/task/${id}`)
+  return http.get<Task<T>>(`/tasks/${id}`)
 }
 
 export function deleteTask(id: string) {
-  return http.delete<void>(`/task/${id}`)
+  return http.delete<void>(`/tasks/${id}`)
 }
 
 /// auth

--- a/web/src/api/upload-manager/chunk-task.ts
+++ b/web/src/api/upload-manager/chunk-task.ts
@@ -195,8 +195,12 @@ export default abstract class ChunkUploadTask extends UploadTask {
     return this._request(
       {
         method: 'post',
-        url: `/upload/${this.task.path}`,
-        params: { override: true, size: this.task.size },
+        url: '/prepare-upload',
+        params: {
+          path: this.task.path,
+          override: true,
+          size: this.task.size,
+        },
         data,
       },
       http

--- a/web/src/api/upload-manager/task.ts
+++ b/web/src/api/upload-manager/task.ts
@@ -119,8 +119,8 @@ export default abstract class UploadTask {
   }
 
   protected uploadCallback<T = any>(data: O<string>): Promise<T> {
-    return http.post(`/upload/${this.task.path}`, data, {
-      params: { override: true, size: this.task.size },
+    return http.post('/prepare-upload', data, {
+      params: { path: this.task.path, override: true, size: this.task.size },
     })
   }
 

--- a/web/src/api/upload-manager/upload-providers/dispatcher.ts
+++ b/web/src/api/upload-manager/upload-providers/dispatcher.ts
@@ -50,10 +50,14 @@ class DispatcherUploadTask extends UploadTask {
     let uploadConfig: any
     try {
       uploadConfig = await http.post(
-        `/upload/${this.task.path}`,
+        '/prepare-upload',
         {},
         {
-          params: { override: this.task.override, size: this.task.size },
+          params: {
+            path: this.task.path,
+            override: this.task.override,
+            size: this.task.size,
+          },
         }
       )
     } catch (e: any) {

--- a/web/src/api/upload-manager/upload-providers/local-chunk.ts
+++ b/web/src/api/upload-manager/upload-providers/local-chunk.ts
@@ -16,8 +16,8 @@ export default class LocalChunkUploadTask extends ChunkUploadTask {
     const data: any = await this._request(
       {
         method: 'post',
-        url: '/chunk',
-        params: { size, chunkSize: 5 * 1024 * 1024 },
+        url: '/chunk-uploads',
+        data: { size, chunkSize: 5 * 1024 * 1024 },
       },
       http
     )
@@ -34,7 +34,7 @@ export default class LocalChunkUploadTask extends ChunkUploadTask {
     return this._request(
       {
         method: 'put',
-        url: `/chunk/${this._uploadId}/${seq}`,
+        url: `/chunk-uploads/${this._uploadId}/chunks/${seq}`,
         data: blob,
         headers: { 'Content-Type': 'application/octet-stream' },
         transformRequest: (d) => d,
@@ -52,8 +52,9 @@ export default class LocalChunkUploadTask extends ChunkUploadTask {
     this._mergeLock = true
     try {
       return await taskDone(
-        http.post<Task>(`/chunk-content/${this.task.path}`, null, {
-          params: { id: this._uploadId, override: this.task.override ? '1' : '' },
+        http.post<Task>(`/chunk-uploads/${this._uploadId}/completion`, {
+          path: this.task.path,
+          override: this.task.override,
         }),
         (task) => {
           this._mergeTask = task
@@ -90,7 +91,7 @@ export default class LocalChunkUploadTask extends ChunkUploadTask {
   override _cleanup() {
     super._cleanup()
     if (!this.isStatus(STATUS_COMPLETED)) {
-      http.delete(`/chunk/${this._uploadId}`)
+      http.delete(`/chunk-uploads/${this._uploadId}`)
     }
   }
 }

--- a/web/src/api/upload-manager/upload-providers/local.ts
+++ b/web/src/api/upload-manager/upload-providers/local.ts
@@ -22,8 +22,11 @@ export default class LocalUploadTask extends UploadTask {
   override async start() {
     if ((await super.start()) === false) return false
 
-    const task = http.put<Task>(`/content/${this.task.path}`, this.task.file, {
-      params: { override: this.task.override ? '1' : '' },
+    const task = http.post<Task>('/write', this.task.file, {
+      params: {
+        path: this.task.path,
+        override: this.task.override ? '1' : '',
+      },
       transformRequest: (d) => d,
       onUploadProgress: ({ loaded, total }) => {
         this._onChange(STATUS_UPLOADING, { loaded, total })


### PR DESCRIPTION
## Summary

- normalize admin and task routes around consistent plural resource names
- replace drive wildcard routes with verb-oriented operations and query-string paths
- model chunk uploads as explicit resources with JSON request bodies
- update frontend callers, signed URLs, thumbnail URLs, and route contract tests

This is intentionally a breaking change. The frontend and backend are distributed together, so legacy routes are removed without compatibility aliases.

## API comparison

### Tasks

| Old | New |
| --- | --- |
| `GET /task/:id` | `GET /tasks/:id` |
| `DELETE /task/:id` | `DELETE /tasks/:id` |

### Admin resources

| Old | New |
| --- | --- |
| `GET /admin/user/:username` | `GET /admin/users/:username` |
| `POST /admin/user` | `POST /admin/users` |
| `PUT /admin/user/:username` | `PUT /admin/users/:username` |
| `DELETE /admin/user/:username` | `DELETE /admin/users/:username` |
| `GET /admin/group/:name` | `GET /admin/groups/:name` |
| `POST /admin/group` | `POST /admin/groups` |
| `PUT /admin/group/:name` | `PUT /admin/groups/:name` |
| `DELETE /admin/group/:name` | `DELETE /admin/groups/:name` |
| `POST /admin/drive` | `POST /admin/drives` |
| `PUT /admin/drive/:name` | `PUT /admin/drives/:name` |
| `DELETE /admin/drive/:name` | `DELETE /admin/drives/:name` |
| `POST /admin/drive/:name/init-config` | `POST /admin/drives/:name/init-config` |
| `POST /admin/drive/:name/init` | `POST /admin/drives/:name/init` |
| `GET /admin/path-permissions/*path` | `GET /admin/path-permissions?path=...` |
| `PUT /admin/path-permissions/*path` | `PUT /admin/path-permissions?path=...` |
| `GET /admin/path-meta` | `GET /admin/path-metadata` |
| `POST /admin/path-meta/*path` | `PUT /admin/path-metadata?path=...` |
| `DELETE /admin/path-meta/*path` | `DELETE /admin/path-metadata?path=...` |
| `POST /admin/mount/*to` | `PUT /admin/path-mounts?path=...` |
| `POST /admin/search/index/*path` | `PUT /admin/search-indexes?path=...` |
| `POST /admin/clean-permissions-mounts` | `POST /admin/maintenance/path-rules/cleanup` |
| `DELETE /admin/drive-cache/:name` | `DELETE /admin/drives/:name/cache` |

### Admin scripts, jobs, and bucket configuration

| Old | New |
| --- | --- |
| `GET /admin/scripts/available` | `GET /admin/drive-scripts/available` |
| `GET /admin/scripts/installed` | `GET /admin/drive-scripts/installed` |
| `POST /admin/scripts/install/:name` | `PUT /admin/drive-scripts/:name` |
| `DELETE /admin/scripts/uninstall/:name` | `DELETE /admin/drive-scripts/:name` |
| `GET /admin/scripts/content/:name` | `GET /admin/drive-scripts/:name/content` |
| `PUT /admin/scripts/content/:name` | `PUT /admin/drive-scripts/:name/content` |
| `GET /admin/jobs/definitions` | `GET /admin/job-definitions` |
| `GET /admin/jobs/executions` | `GET /admin/job-executions` |
| `POST /admin/jobs/execution` | `POST /admin/job-executions` |
| `PUT /admin/jobs/execution/:id/cancel` | `POST /admin/job-executions/:id/cancel` |
| `DELETE /admin/jobs/execution/:id` | `DELETE /admin/job-executions/:id` |
| `DELETE /admin/jobs/execution?jobId=...` | `DELETE /admin/job-executions?jobId=...` |
| `POST /admin/jobs/script-eval` | `POST /admin/job-script-evaluations` |
| `POST /admin/file-bucket` | `POST /admin/file-buckets` |
| `PUT /admin/file-bucket/:name` | `PUT /admin/file-buckets/:name` |
| `DELETE /admin/file-bucket/:name` | `DELETE /admin/file-buckets/:name` |

### Drive operations

| Old | New |
| --- | --- |
| `GET /entry/*path` | `GET /stat?path=...` |
| `GET /entries/*path` | `GET /list?path=...` |
| `POST /mkdir/*path` | `POST /mkdir?path=...` |
| `DELETE /entry/*path` | `POST /delete?path=...` |
| `POST /upload/*path` | `POST /prepare-upload?path=...&size=...&override=...` |
| `PUT /content/*path` | `POST /write?path=...&override=...` |
| `GET or HEAD /content/*path` | `GET or HEAD /download?path=...` |
| `GET /thumbnail/*path` | `GET /thumbnail?path=...` |
| `GET /search/*path` | `GET /search?path=...&q=...&next=...` |
| `POST /zip` | `POST /archive` |

`POST /copy` and `POST /move` retain their operation paths, but now require explicit `from` and `to` query parameters.

### Chunk uploads

| Old | New |
| --- | --- |
| `POST /chunk?size=...&chunkSize=...` | `POST /chunk-uploads` with JSON `{ "size": ..., "chunkSize": ... }` |
| `PUT /chunk/:id/:seq` | `PUT /chunk-uploads/:id/chunks/:seq` |
| `POST /chunk-content/*path?id=...&override=...` | `POST /chunk-uploads/:id/completion` with JSON `{ "path": "...", "override": ... }` |
| `DELETE /chunk/:id` | `DELETE /chunk-uploads/:id` |

## Path behavior

- path-bearing drive and admin operations use required query parameters
- the root path must be passed explicitly as `path=`
- paths are normalized centrally before use
- signed download and thumbnail requests bind the signature to the normalized query path
- no `/fs` prefix is introduced
- WebDAV and file transfer bucket routes under `/f/:name/*path` are unchanged

## Validation

- `GOCACHE=/tmp/go-drive-api-routes-build go test ./server` (65 passed)
- `npm run lint`
- `npm run build-web`
- `git diff --check`
- full `go test ./...`: 309 passed; only WebDAV `TestPrefix` failed because the sandbox cannot bind `[::1]:0`