### PR TITLE
fix(web): improve keyboard and screen reader access

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/web/src/components/DialogView/index.vue
+++ b/web/src/components/DialogView/index.vue
@@ -83,6 +83,9 @@ const props = defineProps({
   title: {
     type: [String, Object] as PropType<I18nText>,
   },
+  accessibleLabel: {
+    type: [String, Object] as PropType<I18nText>,
+  },
   transition: {
     type: String,
     default: 'fade-scale-up',
@@ -121,7 +124,13 @@ const contentEl = ref<HTMLElement | null>(null)
 let scrollLocked = false
 let lastFocused: HTMLElement | null = null
 
-const ariaLabel = computed(() => (props.title ? s(props.title) : undefined))
+const ariaLabel = computed(() =>
+  props.accessibleLabel
+    ? s(props.accessibleLabel)
+    : props.title
+      ? s(props.title)
+      : undefined
+)
 const closeLabel = computed(() => s(T('dialog.base.close')))
 
 const overlayClicked = (e: MouseEvent) => {

--- a/web/src/components/FloatButton/FloatButton.vue
+++ b/web/src/components/FloatButton/FloatButton.vue
@@ -5,19 +5,42 @@
       `float-button__posi-${position}`,
       modelValue ? 'float-button--active' : '',
     ]"
+    @focusout="onFocusOut"
   >
+    <button
+      ref="triggerEl"
+      type="button"
+      class="float-button__trigger"
+      data-ui="button"
+      :title="title"
+      aria-haspopup="menu"
+      :aria-expanded="modelValue"
+      @click.capture.stop="triggerClicked"
+      @keydown.down.prevent="openFromKeyboard"
+      @keydown.esc.prevent="closeFromKeyboard"
+      @mouseenter="mouseEnter"
+      @mouseleave="mouseLeave"
+    >
+      <slot />
+    </button>
     <div
       class="float-button__buttons"
+      :role="modelValue ? 'menu' : undefined"
+      @keydown="onMenuKeydown"
       @mouseenter="mouseEnter"
       @mouseleave="mouseLeave"
     >
       <Transition v-for="(b, i) in buttons" :key="i" name="fade-scale">
         <button
+          ref="buttonEls"
+          type="button"
           v-show="modelValue"
           class="float-button__button"
           data-ui="button"
+          role="menuitem"
           :title="s(b.title)"
           @click="buttonClicked(b, i)"
+          @keydown.esc.prevent="closeFromKeyboard"
         >
           <slot v-if="$slots[b.slot]" :name="b.slot"></slot>
           <template v-else>
@@ -26,20 +49,11 @@
         </button>
       </Transition>
     </div>
-    <button
-      class="float-button__trigger"
-      data-ui="button"
-      :title="title"
-      @click.capture.stop="triggerClicked"
-      @mouseenter="mouseEnter"
-      @mouseleave="mouseLeave"
-    >
-      <slot />
-    </button>
   </div>
 </template>
 <script setup lang="ts">
 import type { FloatButtonItem, FloatButtonClickEventData } from '.'
+import { nextTick, ref } from 'vue'
 
 const props = defineProps({
   modelValue: {
@@ -68,10 +82,14 @@ const emit = defineEmits<{
 }>()
 
 let leaveTimer: number | undefined
+let enterTimer: number | undefined
+const triggerEl = ref<HTMLButtonElement>()
+const buttonEls = ref<HTMLButtonElement[]>([])
 
 const mouseEnter = () => {
   clearTimeout(leaveTimer)
-  setTimeout(() => {
+  clearTimeout(enterTimer)
+  enterTimer = window.setTimeout(() => {
     const show = true
     emit('update:modelValue', show)
   }, 0)
@@ -79,21 +97,66 @@ const mouseEnter = () => {
 
 const mouseLeave = () => {
   clearTimeout(leaveTimer)
+  clearTimeout(enterTimer)
   leaveTimer = setTimeout(() => {
     const show = false
     emit('update:modelValue', show)
   }, 100) as unknown as number
 }
 
-const triggerClicked = () => {
+const triggerClicked = (e: MouseEvent) => {
   clearTimeout(leaveTimer)
+  clearTimeout(enterTimer)
   const show = !props.modelValue
   emit('update:modelValue', show)
+  if (show && e.detail === 0) {
+    nextTick(() => buttonEls.value[0]?.focus())
+  }
 }
 
 const buttonClicked = (button: FloatButtonItem, index: number) => {
+  clearTimeout(enterTimer)
   emit('update:modelValue', false)
   emit('click', { button, index })
+}
+
+const openFromKeyboard = () => {
+  clearTimeout(enterTimer)
+  emit('update:modelValue', true)
+  nextTick(() => buttonEls.value[0]?.focus())
+}
+
+const closeFromKeyboard = () => {
+  clearTimeout(enterTimer)
+  clearTimeout(leaveTimer)
+  emit('update:modelValue', false)
+  nextTick(() => triggerEl.value?.focus())
+}
+
+const onMenuKeydown = (e: KeyboardEvent) => {
+  const items = buttonEls.value.filter((button) => !button.disabled)
+  if (!items.length) return
+  const activeIndex = items.indexOf(document.activeElement as HTMLButtonElement)
+  let nextIndex: number | undefined
+  if (e.key === 'ArrowDown') nextIndex = (activeIndex + 1) % items.length
+  else if (e.key === 'ArrowUp') {
+    nextIndex = (activeIndex - 1 + items.length) % items.length
+  } else if (e.key === 'Home') nextIndex = 0
+  else if (e.key === 'End') nextIndex = items.length - 1
+  if (nextIndex !== undefined) {
+    e.preventDefault()
+    items[nextIndex].focus()
+  }
+}
+
+const onFocusOut = (e: FocusEvent) => {
+  const next = e.relatedTarget
+  if (next instanceof Node && triggerEl.value?.parentElement?.contains(next)) {
+    return
+  }
+  clearTimeout(enterTimer)
+  clearTimeout(leaveTimer)
+  emit('update:modelValue', false)
 }
 </script>
 <style lang="scss">

--- a/web/src/components/Form/FormItem.vue
+++ b/web/src/components/Form/FormItem.vue
@@ -52,8 +52,12 @@
         :name="item.field"
         :value="modelValue"
         :placeholder="s(item.placeholder)"
+        :aria-label="s(item.ariaLabel)"
+        :autocomplete="item.autocomplete"
         :required="item.required"
         :disabled="disabled || item.disabled"
+        :aria-invalid="error ? 'true' : undefined"
+        :aria-describedby="error ? errorId : undefined"
         rows="4"
         @input="textInput"
       />
@@ -65,8 +69,12 @@
         :name="item.field"
         :value="modelValue"
         :placeholder="s(item.placeholder)"
+        :aria-label="s(item.ariaLabel)"
+        :autocomplete="item.autocomplete"
         :required="item.required"
         :disabled="disabled || item.disabled"
+        :aria-invalid="error ? 'true' : undefined"
+        :aria-describedby="error ? errorId : undefined"
         @input="textInput"
       />
       <input
@@ -77,8 +85,12 @@
         :name="item.field"
         :value="modelValue"
         :placeholder="s(item.placeholder)"
+        :aria-label="s(item.ariaLabel)"
+        :autocomplete="item.autocomplete"
         :required="item.required"
         :disabled="disabled || item.disabled"
+        :aria-invalid="error ? 'true' : undefined"
+        :aria-describedby="error ? errorId : undefined"
         @input="textInput"
       />
       <input
@@ -90,6 +102,8 @@
         :checked="!!modelValue"
         :required="item.required"
         :disabled="disabled || item.disabled"
+        :aria-invalid="error ? 'true' : undefined"
+        :aria-describedby="error ? errorId : undefined"
         @input="checkboxInput"
       />
       <div
@@ -121,6 +135,8 @@
         :value="modelValue"
         :required="item.required"
         :disabled="disabled || item.disabled"
+        :aria-invalid="error ? 'true' : undefined"
+        :aria-describedby="error ? errorId : undefined"
         @input="selectInput"
       >
         <option
@@ -143,6 +159,8 @@
           :placeholder="s(item.placeholder)"
           :required="item.required"
           :disabled="disabled || item.disabled"
+          :aria-invalid="error ? 'true' : undefined"
+          :aria-describedby="error ? errorId : undefined"
           @input="textInput"
         />
         <button
@@ -172,7 +190,12 @@
         @update:model-value="stringInput"
       />
     </div>
-    <span v-if="error" class="form-item-error">{{ error }}</span>
+    <span
+      v-if="error"
+      :id="errorId"
+      class="form-item-error"
+      role="alert"
+    >{{ error }}</span>
   </div>
 </template>
 <script setup lang="ts">
@@ -273,6 +296,9 @@ const valueId = computed(() => {
   if (props.item.type === 'form' || props.item.type === 'code' || props.item.type === 'checkboxes') return
   return props.id
 })
+const errorId = computed(() =>
+  props.id ? `${props.id}-error` : undefined
+)
 
 const checkboxesSelectedSet = computed(() => {
   if (props.item.type !== 'checkboxes') return new Set<string>()

--- a/web/src/components/Form/FormItemForm.vue
+++ b/web/src/components/Form/FormItemForm.vue
@@ -25,22 +25,17 @@
       </template>
     </div>
     <div v-if="!disabled && addable">
-      <SimpleDropdown v-model="addDropdownShowing" position="bottom-right">
-        <SimpleButton icon="add" native-type="button">{{
-          forms.addText
-        }}</SimpleButton>
-        <template #dropdown>
-          <ul class="form-item__form-types">
-            <li
-              v-for="s in forms.forms"
-              :key="s.key"
-              class="form-item__form-type"
-              @click="addForm(s.key)"
-            >
-              {{ s.name }}
-            </li>
-          </ul>
-        </template>
+      <SimpleDropdown
+        position="bottom-right"
+        :aria-label="forms.addText?.toString()"
+        :items="forms.forms"
+        menu-max-height="100px"
+        @select="addForm"
+      >
+        <span class="form-item__form-add">
+          <Icon name="add" aria-hidden="true" />
+          <span>{{ forms.addText }}</span>
+        </span>
       </SimpleDropdown>
     </div>
   </div>
@@ -79,8 +74,6 @@ const emit = defineEmits<{
 
 const formsEl = ref<InstanceType<typeof SimpleForm>[]>([])
 
-const addDropdownShowing = ref(false)
-
 const value = ref<ValueItem[]>([])
 
 const forms = computed(() => props.item.forms || { forms: [] })
@@ -99,7 +92,6 @@ const addForm = (typeKey: string) => {
     typeKey,
     value: {},
   })
-  addDropdownShowing.value = false
   emitValue()
 }
 
@@ -194,27 +186,15 @@ defineExpose({ validate })
   }
 }
 
-.form-item__form-types {
-  margin: 0;
-  padding: 0;
-  max-height: 100px;
-  overflow-y: auto;
+.form-item__form-add {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border-radius: var(--radius-control);
+  padding: 4px 10px;
+  background-color: var(--color-accent-strong);
+  color: var(--color-on-accent);
+  line-height: 20px;
 }
 
-.form-item__form-type {
-  margin: 0;
-  list-style-type: none;
-  white-space: nowrap;
-  padding: 6px 12px;
-  cursor: pointer;
-  font-size: 14px;
-
-  &:hover {
-    background-color: var(--color-bg-hover);
-  }
-
-  &.active {
-    background-color: var(--color-bg-selected);
-  }
-}
 </style>

--- a/web/src/components/ProgressBar.vue
+++ b/web/src/components/ProgressBar.vue
@@ -1,5 +1,14 @@
 <template>
-  <div class="progress-bar">
+  <div
+    class="progress-bar"
+    :role="typeof progress === 'number' ? 'progressbar' : undefined"
+    :aria-label="
+      typeof progress === 'number' ? $t('app.loading') : undefined
+    "
+    :aria-valuemin="typeof progress === 'number' ? 0 : undefined"
+    :aria-valuemax="typeof progress === 'number' ? 100 : undefined"
+    :aria-valuenow="typeof progress === 'number' ? progress : undefined"
+  >
     <div
       v-if="typeof progress === 'number'"
       class="progress-bar__inner"

--- a/web/src/components/SimpleDropdown.vue
+++ b/web/src/components/SimpleDropdown.vue
@@ -6,19 +6,19 @@
     :class="{ active }"
     @focusout="onFocusOut"
   >
-    <span
+    <button
       ref="triggerEl"
+      type="button"
       class="simple-dropdown__trigger"
       data-ui="dropdown-trigger"
-      role="button"
-      tabindex="0"
-      aria-haspopup="true"
+      aria-haspopup="menu"
+      :aria-label="ariaLabel"
       :aria-expanded="active"
       @click="triggerClicked"
       @keydown="onTriggerKeydown"
     >
       <slot />
-    </span>
+    </button>
     <Teleport to="body">
       <Transition :name="dropdownTransition">
         <div
@@ -27,10 +27,33 @@
           class="simple-dropdown__dropdown glass-surface"
           data-ui="dropdown-panel"
           data-surface="glass"
+          role="menu"
           :style="dropdownStyle"
           @keydown="onDropdownKeydown"
         >
-          <slot name="dropdown" />
+          <ul
+            class="simple-dropdown__menu"
+            :style="menuMaxHeight ? { maxHeight: menuMaxHeight } : undefined"
+          >
+            <li
+              v-for="item in items"
+              :key="item.key"
+              class="simple-dropdown__item"
+              :class="{
+                active: item.key === selectedKey,
+                disabled: item.disabled,
+              }"
+              :role="hasSelection ? 'menuitemradio' : 'menuitem'"
+              tabindex="-1"
+              :aria-checked="hasSelection ? item.key === selectedKey : undefined"
+              :aria-disabled="item.disabled || undefined"
+              @click="selectItem(item)"
+              @keydown.enter.prevent="selectItem(item)"
+              @keydown.space.prevent="selectItem(item)"
+            >
+              <slot name="item" :item="item">{{ item.name }}</slot>
+            </li>
+          </ul>
         </div>
       </Transition>
     </Teleport>
@@ -47,6 +70,12 @@ import {
   PropType,
 } from 'vue'
 
+interface SimpleDropdownItem {
+  key: string
+  name?: I18nText
+  disabled?: boolean
+}
+
 const props = defineProps({
   modelValue: {
     type: Boolean,
@@ -59,8 +88,24 @@ const props = defineProps({
     type: String as PropType<'bottom-left' | 'bottom-right'>,
     default: 'bottom-left',
   },
+  ariaLabel: {
+    type: String,
+  },
+  items: {
+    type: Array as PropType<SimpleDropdownItem[]>,
+    default: () => [],
+  },
+  selectedKey: {
+    type: String,
+  },
+  menuMaxHeight: {
+    type: String,
+  },
 })
-const emit = defineEmits<{ (e: 'update:modelValue', v: boolean): void }>()
+const emit = defineEmits<{
+  (e: 'update:modelValue', v: boolean): void
+  (e: 'select', key: string, item: SimpleDropdownItem): void
+}>()
 
 const active = ref(false)
 const rootEl = ref<HTMLElement | null>(null)
@@ -68,6 +113,8 @@ const triggerEl = ref<HTMLElement | null>(null)
 const dropdownEl = ref<HTMLElement | null>(null)
 const dropdownStyle = ref<Record<string, string>>({})
 const dropdownPlacedAbove = ref(false)
+const focusMenuOnOpen = ref(false)
+const hasSelection = computed(() => props.selectedKey !== undefined)
 const dropdownTransition = computed(() =>
   props.transition === 'fade-slide-down' && dropdownPlacedAbove.value
     ? 'fade-slide-up'
@@ -85,6 +132,7 @@ const setActive = (v: boolean) => {
 }
 
 const triggerClicked = () => {
+  focusMenuOnOpen.value = false
   setActive(!active.value)
 }
 
@@ -93,13 +141,38 @@ const close = (focusTrigger = false) => {
   if (focusTrigger) triggerEl.value?.focus()
 }
 
+const focusInitialMenuItem = async () => {
+  await nextTick()
+  const items = getMenuItems()
+  const selected = items.find(
+    (item) => item.getAttribute('aria-checked') === 'true'
+  )
+  const itemToFocus = selected ?? items[0]
+  itemToFocus?.focus()
+  focusMenuOnOpen.value = false
+}
+
+const selectItem = (item: SimpleDropdownItem) => {
+  if (item.disabled) return
+  emit('select', item.key, item)
+  close(true)
+}
+
 const onTriggerKeydown = (e: KeyboardEvent) => {
   if (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar') {
     e.preventDefault()
-    setActive(!active.value)
+    if (active.value) close(true)
+    else {
+      focusMenuOnOpen.value = true
+      setActive(true)
+    }
   } else if (e.key === 'ArrowDown') {
     e.preventDefault()
-    setActive(true)
+    if (active.value) void focusInitialMenuItem()
+    else {
+      focusMenuOnOpen.value = true
+      setActive(true)
+    }
   } else if (e.key === 'Escape' && active.value) {
     e.preventDefault()
     close(true)
@@ -110,8 +183,34 @@ const onDropdownKeydown = (e: KeyboardEvent) => {
   if (e.key === 'Escape') {
     e.preventDefault()
     close(true)
+    return
+  }
+
+  const items = getMenuItems()
+  if (!items.length) return
+  const activeIndex = items.indexOf(document.activeElement as HTMLElement)
+  let nextIndex: number | undefined
+  if (e.key === 'ArrowDown') nextIndex = (activeIndex + 1) % items.length
+  else if (e.key === 'ArrowUp') {
+    nextIndex = (activeIndex - 1 + items.length) % items.length
+  } else if (e.key === 'Home') nextIndex = 0
+  else if (e.key === 'End') nextIndex = items.length - 1
+  else if (e.key === 'Tab') {
+    close()
+    return
+  }
+  if (nextIndex !== undefined) {
+    e.preventDefault()
+    items[nextIndex].focus()
   }
 }
+
+const getMenuItems = () =>
+  Array.from(
+    dropdownEl.value?.querySelectorAll<HTMLElement>(
+      '[role="menuitem"],[role="menuitemradio"],[role="menuitemcheckbox"]'
+    ) ?? []
+  ).filter((el) => el.getAttribute('aria-disabled') !== 'true')
 
 // Close when focus moves outside the component (e.g. keyboard Tab).
 // Clicking a non-focusable item keeps focus on the trigger, so this does
@@ -143,8 +242,7 @@ const onDocumentPointerDown = (e: Event) => {
 
 const bindOutside = (bind: boolean) => {
   const fn = bind ? 'addEventListener' : 'removeEventListener'
-  document[fn]('mousedown', onDocumentPointerDown, true)
-  document[fn]('touchstart', onDocumentPointerDown, true)
+  document[fn]('pointerdown', onDocumentPointerDown, true)
 }
 
 const updateDropdownPosition = () => {
@@ -155,7 +253,15 @@ const updateDropdownPosition = () => {
   const triggerRect = trigger.getBoundingClientRect()
   const gap = 10
   const viewportPadding = 8
-  const dropdownWidth = dropdown.offsetWidth
+  const availableWidth = Math.max(
+    window.innerWidth - viewportPadding * 2,
+    0
+  )
+  const minWidth = Math.min(triggerRect.width, availableWidth)
+  const dropdownWidth = Math.min(
+    Math.max(dropdown.offsetWidth, minWidth),
+    availableWidth
+  )
   const dropdownHeight = dropdown.offsetHeight
 
   let left =
@@ -182,6 +288,8 @@ const updateDropdownPosition = () => {
   dropdownStyle.value = {
     left: `${Math.round(left)}px`,
     top: `${Math.round(top)}px`,
+    minWidth: `${Math.round(minWidth)}px`,
+    maxWidth: `${Math.round(availableWidth)}px`,
   }
 }
 
@@ -197,6 +305,7 @@ watch(active, async (v) => {
   if (v) {
     await nextTick()
     updateDropdownPosition()
+    if (focusMenuOnOpen.value) await focusInitialMenuItem()
   }
 })
 
@@ -215,15 +324,84 @@ onBeforeUnmount(() => {
   display: inline-flex;
   align-items: center;
   cursor: pointer;
+  padding: 0;
+  border: 0;
   border-radius: 2px;
+  background: transparent;
+  color: inherit;
+  font: inherit;
 }
 
 .simple-dropdown__dropdown {
   position: fixed;
   z-index: 1001;
+  box-sizing: border-box;
+  width: max-content;
+  border: 1px solid var(--color-glass-border);
   border-radius: var(--radius-popover);
+  outline: none;
   overflow: hidden;
   background-color: var(--color-bg-glass);
   box-shadow: var(--shadow-elevated);
+}
+
+.simple-dropdown__menu {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  overflow-y: auto;
+}
+
+.simple-dropdown__item {
+  margin: 0;
+  box-sizing: border-box;
+  width: 100%;
+  list-style-type: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding: 6px 12px;
+  cursor: pointer;
+  font-size: 14px;
+
+  &:hover,
+  &:focus-visible {
+    background-color: var(--color-bg-hover);
+  }
+
+  &:focus-visible {
+    outline: 2px solid transparent;
+    outline-offset: -2px;
+    box-shadow: inset 0 0 0 2px var(--color-focus-ring);
+  }
+
+  &.active {
+    background-color: var(--color-bg-selected);
+  }
+
+  &.disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+
+  &:first-child {
+    border-radius:
+      calc(var(--radius-popover) - 1px)
+      calc(var(--radius-popover) - 1px)
+      0
+      0;
+  }
+
+  &:last-child {
+    border-radius:
+      0
+      0
+      calc(var(--radius-popover) - 1px)
+      calc(var(--radius-popover) - 1px);
+  }
+
+  &:only-child {
+    border-radius: calc(var(--radius-popover) - 1px);
+  }
 }
 </style>

--- a/web/src/components/entry/EntryList.vue
+++ b/web/src/components/entry/EntryList.vue
@@ -27,22 +27,17 @@
         >
           <Icon :name="validViewMode === 'list' ? 'grid' : 'list'" />
         </button>
-        <SimpleDropdown v-model="sortDropdownShowing">
+        <SimpleDropdown
+          :aria-label="$t('app.toggle_sort')"
+          :items="sortModes"
+          :selected-key="validSort"
+          @select="setSortBy"
+        >
           <span :title="$t('app.toggle_sort')">
             <Icon name="sort" />
           </span>
-          <template #dropdown>
-            <ul class="sort-modes">
-              <li
-                v-for="s in sortModes"
-                :key="s.key"
-                class="sort-mode"
-                :class="{ active: validSort === s.key }"
-                @click="setSortBy(s.key)"
-              >
-                {{ $t(s.name) }}
-              </li>
-            </ul>
+          <template #item="{ item }">
+            {{ $t(item.name?.toString() ?? '') }}
           </template>
         </SimpleDropdown>
       </div>
@@ -197,7 +192,6 @@ const emit = defineEmits<{
 }>()
 
 const selected = ref<Entry[]>([])
-const sortDropdownShowing = ref(false)
 
 const validViewMode = computed(
   () =>
@@ -355,7 +349,6 @@ const parentIconClicked = (e: MouseEvent) => {
 
 const setSortBy = (sort: string) => {
   emit('update:sort', sort)
-  sortDropdownShowing.value = false
 }
 
 const focusOnEntry = async (name: string) => {
@@ -468,28 +461,6 @@ defineExpose({
     font-size: 16px;
   }
 
-}
-
-.sort-modes {
-  margin: 0;
-  padding: 0;
-}
-
-.sort-mode {
-  margin: 0;
-  list-style-type: none;
-  white-space: nowrap;
-  padding: 6px 12px;
-  cursor: pointer;
-  font-size: 14px;
-
-  &:hover {
-    background-color: var(--color-bg-hover);
-  }
-
-  &.active {
-    background-color: var(--color-bg-selected);
-  }
 }
 
 .entry-list--view-thumbnail {

--- a/web/src/handlers/HandlerViewDialog.vue
+++ b/web/src/handlers/HandlerViewDialog.vue
@@ -1,5 +1,11 @@
 <template>
-  <DialogView class="entry-handler-dialog" eager :show="showing" :fullscreen="dialogStyle.fullscreen">
+  <DialogView
+    class="entry-handler-dialog"
+    eager
+    :show="showing"
+    :fullscreen="dialogStyle.fullscreen"
+    :accessible-label="dialogLabel"
+  >
     <HandlerView ref="view" v-bind="events" />
   </DialogView>
 </template>
@@ -30,6 +36,7 @@ const events = {
 
 const view = ref<InstanceType<typeof HandlerView> | null>(null)
 const showing = computed(() => view.value?.showing)
+const dialogLabel = ref('')
 
 const handle: EntryHandlerViewHandle = {
   get handler() {
@@ -52,6 +59,9 @@ const handle: EntryHandlerViewHandle = {
     handlerName = handlerName_
     opt = opt_
     data = data_
+    dialogLabel.value = Array.isArray(data_.entry)
+      ? data_.entry.map((entry) => entry.name).join(', ')
+      : data_.entry.name
 
     const handler = getHandler(handlerName)
     dialogStyle.fullscreen = handler?.style?.fullscreen ?? false

--- a/web/src/handlers/audio/AudioView.vue
+++ b/web/src/handlers/audio/AudioView.vue
@@ -29,7 +29,15 @@
         <div
           ref="progressEl"
           class="audio-player__bar"
+          role="slider"
+          tabindex="0"
+          :aria-label="$t('handler.audio.progress')"
+          aria-valuemin="0"
+          :aria-valuemax="duration"
+          :aria-valuenow="currentTime"
+          :aria-valuetext="`${formatTime(currentTime)} / ${formatTime(duration)}`"
           @pointerdown="onProgressDown"
+          @keydown="onProgressKeydown"
         >
           <div class="audio-player__bar-bg">
             <div
@@ -57,6 +65,7 @@
             data-variant="plain"
             :class="{ 'is-active': shuffle }"
             :title="$t('handler.audio.shuffle')"
+            :aria-pressed="shuffle"
             @click="shuffle = !shuffle; if (shuffle) repeatOne = false"
           >
             <svg viewBox="0 0 24 24" class="audio-player__icon">
@@ -80,6 +89,7 @@
             data-variant="plain"
             :class="{ 'is-active': repeatOne }"
             :title="$t('handler.audio.repeat_one')"
+            :aria-pressed="repeatOne"
             @click="repeatOne = !repeatOne; if (repeatOne) shuffle = false"
           >
             <svg viewBox="0 0 24 24" class="audio-player__icon">
@@ -165,7 +175,15 @@
           <div
             ref="volumeEl"
             class="audio-player__volume-bar"
+            role="slider"
+            tabindex="0"
+            :aria-label="$t('handler.audio.volume')"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            :aria-valuenow="Math.round((muted ? 0 : volume) * 100)"
+            :aria-valuetext="`${Math.round((muted ? 0 : volume) * 100)}%`"
             @pointerdown="onVolumeDown"
+            @keydown="onVolumeKeydown"
           >
             <div class="audio-player__volume-bg">
               <div
@@ -182,27 +200,33 @@
       </div>
     </div>
 
-    <ul class="audio-player__list">
+    <ul class="audio-player__list" :aria-label="$t('handler.audio.playlist')">
       <li
         v-for="(track, index) in tracks"
         :key="track.path"
         class="audio-player__list-item"
         :class="{ 'is-current': index === currentIndex }"
-        @click="switchTo(index, true)"
       >
-        <span class="audio-player__list-index">
-          <svg
-            v-if="index === currentIndex && playing"
-            viewBox="0 0 24 24"
-            class="audio-player__list-playing"
-          >
-            <path fill="currentColor" d="M8 5v14l11-7L8 5z" />
-          </svg>
-          <template v-else>{{ index + 1 }}</template>
-        </span>
-        <span class="audio-player__list-name" :title="track.name">{{
-          track.name
-        }}</span>
+        <button
+          type="button"
+          class="audio-player__list-button"
+          :aria-current="index === currentIndex ? 'true' : undefined"
+          @click="switchTo(index, true)"
+        >
+          <span class="audio-player__list-index">
+            <svg
+              v-if="index === currentIndex && playing"
+              viewBox="0 0 24 24"
+              class="audio-player__list-playing"
+            >
+              <path fill="currentColor" d="M8 5v14l11-7L8 5z" />
+            </svg>
+            <template v-else>{{ index + 1 }}</template>
+          </span>
+          <span class="audio-player__list-name" :title="track.name">{{
+            track.name
+          }}</span>
+        </button>
       </li>
     </ul>
 
@@ -417,6 +441,30 @@ const setVolumeByRatio = (ratio: number) => {
   applyVolume()
 }
 
+const onProgressKeydown = (e: KeyboardEvent) => {
+  if (duration.value <= 0) return
+  const step = Math.min(30, Math.max(1, duration.value * 0.02))
+  let value = currentTime.value
+  if (e.key === 'ArrowLeft' || e.key === 'ArrowDown') value -= step
+  else if (e.key === 'ArrowRight' || e.key === 'ArrowUp') value += step
+  else if (e.key === 'Home') value = 0
+  else if (e.key === 'End') value = duration.value
+  else return
+  e.preventDefault()
+  seekByRatio(Math.min(1, Math.max(0, value / duration.value)))
+}
+
+const onVolumeKeydown = (e: KeyboardEvent) => {
+  let value = muted.value ? 0 : volume.value
+  if (e.key === 'ArrowLeft' || e.key === 'ArrowDown') value -= 0.1
+  else if (e.key === 'ArrowRight' || e.key === 'ArrowUp') value += 0.1
+  else if (e.key === 'Home') value = 0
+  else if (e.key === 'End') value = 1
+  else return
+  e.preventDefault()
+  setVolumeByRatio(value)
+}
+
 const onProgressDown = createDrag(progressEl, seekByRatio)
 const onVolumeDown = createDrag(volumeEl, setVolumeByRatio)
 
@@ -562,8 +610,16 @@ onUnmounted(() => {
       var(--motion-easing-standard);
   }
 
-  &__bar:hover &__bar-thumb {
+  &__bar:hover &__bar-thumb,
+  &__bar:focus-visible &__bar-thumb {
     opacity: 1;
+  }
+
+  &__bar:focus-visible,
+  &__volume-bar:focus-visible {
+    outline: 2px solid var(--color-focus-ring);
+    outline-offset: 2px;
+    border-radius: 4px;
   }
 
   &__controls {
@@ -685,11 +741,6 @@ onUnmounted(() => {
   }
 
   &__list-item {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    padding: 10px 20px;
-    cursor: pointer;
     border-bottom: solid 1px var(--color-border);
     transition: background-color var(--motion-duration-fast)
       var(--motion-easing-standard);
@@ -711,6 +762,20 @@ onUnmounted(() => {
         font-weight: 500;
       }
     }
+  }
+
+  &__list-button {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    padding: 10px 20px;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
   }
 
   &__list-index {

--- a/web/src/handlers/video/VideoView.vue
+++ b/web/src/handlers/video/VideoView.vue
@@ -14,7 +14,17 @@
       @close="emit('close')"
     />
 
-    <div class="video-player" @click="togglePlay" @dblclick="toggleFullscreen">
+    <div
+      class="video-player"
+      role="button"
+      tabindex="0"
+      :aria-label="
+        playing ? $t('handler.video.pause') : $t('handler.video.play')
+      "
+      @click="togglePlay"
+      @dblclick="toggleFullscreen"
+      @keydown.enter.stop.prevent="togglePlay"
+    >
       <video
         ref="videoEl"
         class="video-player__video"
@@ -33,7 +43,15 @@
       <div
         ref="progressEl"
         class="video-controls__bar"
+        role="slider"
+        tabindex="0"
+        :aria-label="$t('handler.video.progress')"
+        aria-valuemin="0"
+        :aria-valuemax="duration"
+        :aria-valuenow="currentTime"
+        :aria-valuetext="`${formatTime(currentTime)} / ${formatTime(duration)}`"
         @pointerdown="onProgressDown"
+        @keydown.stop="onProgressKeydown"
       >
         <div class="video-controls__bar-bg">
           <div
@@ -107,7 +125,15 @@
           <div
             ref="volumeEl"
             class="video-controls__volume-bar"
+            role="slider"
+            tabindex="0"
+            :aria-label="$t('handler.video.volume')"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            :aria-valuenow="Math.round((muted ? 0 : volume) * 100)"
+            :aria-valuetext="`${Math.round((muted ? 0 : volume) * 100)}%`"
             @pointerdown="onVolumeDown"
+            @keydown.stop="onVolumeKeydown"
           >
             <div class="video-controls__volume-bg">
               <div
@@ -267,6 +293,30 @@ const setVolumeByRatio = (ratio: number) => {
   applyVolume()
 }
 
+const onProgressKeydown = (e: KeyboardEvent) => {
+  if (duration.value <= 0) return
+  let value = currentTime.value
+  if (e.key === 'ArrowLeft' || e.key === 'ArrowDown') value -= seekStep.value
+  else if (e.key === 'ArrowRight' || e.key === 'ArrowUp') {
+    value += seekStep.value
+  } else if (e.key === 'Home') value = 0
+  else if (e.key === 'End') value = duration.value
+  else return
+  e.preventDefault()
+  seekByRatio(Math.min(1, Math.max(0, value / duration.value)))
+}
+
+const onVolumeKeydown = (e: KeyboardEvent) => {
+  let value = muted.value ? 0 : volume.value
+  if (e.key === 'ArrowLeft' || e.key === 'ArrowDown') value -= 0.1
+  else if (e.key === 'ArrowRight' || e.key === 'ArrowUp') value += 0.1
+  else if (e.key === 'Home') value = 0
+  else if (e.key === 'End') value = 1
+  else return
+  e.preventDefault()
+  setVolumeByRatio(value)
+}
+
 const onProgressDown = createDrag(progressEl, seekByRatio)
 const onVolumeDown = createDrag(volumeEl, setVolumeByRatio)
 
@@ -419,6 +469,11 @@ onUnmounted(() => {
   min-height: 0;
   cursor: pointer;
 
+  &:focus-visible {
+    outline: 3px solid var(--color-focus-ring);
+    outline-offset: -3px;
+  }
+
   &__video {
     max-width: 100%;
     max-height: 80vh;
@@ -495,8 +550,16 @@ onUnmounted(() => {
       var(--motion-easing-standard);
   }
 
-  &__bar:hover &__bar-thumb {
+  &__bar:hover &__bar-thumb,
+  &__bar:focus-visible &__bar-thumb {
     opacity: 1;
+  }
+
+  &__bar:focus-visible,
+  &__volume-bar:focus-visible {
+    outline: 2px solid var(--color-focus-ring);
+    outline-offset: 2px;
+    border-radius: 4px;
   }
 
   &__row {

--- a/web/src/i18n/lang/en-US.json
+++ b/web/src/i18n/lang/en-US.json
@@ -32,7 +32,9 @@
     },
     "text": {
       "yes": "Yes",
-      "no": "No"
+      "no": "No",
+      "alert_title": "Notice",
+      "confirm_title": "Confirmation"
     },
     "loading": {
       "cancel": "Cancel"
@@ -43,6 +45,7 @@
     "logout": "Logout",
     "home": "Home",
     "admin": "Admin",
+    "skip_to_content": "Skip to main content",
     "username": "Username",
     "groups": "Groups",
     "file": "File",
@@ -55,6 +58,7 @@
     "toggle_to_thumbnail": "Toggle to thumbnail mode (T)",
     "toggle_sort": "Toggle sort mode",
     "entry_actions": "File actions",
+    "loading": "Loading",
     "password_protected": "Password Required",
     "input_password": "Please input the password",
     "sort": {
@@ -69,7 +73,8 @@
       "placeholder": "Search Files...",
       "searching": "Searching...",
       "search_help": "Try:",
-      "no_result": "No result"
+      "no_result": "No result",
+      "results": "{n} results"
     },
     "task_status_pending": "Pending",
     "task_status_running": "Running",
@@ -448,6 +453,7 @@
       "next": "Next",
       "shuffle": "Shuffle",
       "repeat_one": "Repeat One",
+      "progress": "Playback position",
       "volume": "Volume",
       "mute": "Mute",
       "unmute": "Unmute",
@@ -458,6 +464,8 @@
       "desc": "Play video",
       "play": "Play",
       "pause": "Pause",
+      "progress": "Playback position",
+      "volume": "Volume",
       "mute": "Mute",
       "unmute": "Unmute",
       "fullscreen": "Fullscreen",

--- a/web/src/i18n/lang/ko-KR.json
+++ b/web/src/i18n/lang/ko-KR.json
@@ -32,7 +32,9 @@
     },
     "text": {
       "yes": "예",
-      "no": "아니오"
+      "no": "아니오",
+      "alert_title": "알림",
+      "confirm_title": "확인"
     },
     "loading": {
       "cancel": "취소"
@@ -43,6 +45,7 @@
     "logout": "로그아웃",
     "home": "홈",
     "admin": "관리자",
+    "skip_to_content": "주요 콘텐츠로 건너뛰기",
     "username": "사용자 이름",
     "groups": "그룹",
     "file": "파일",
@@ -55,6 +58,7 @@
     "toggle_to_thumbnail": "썸네일 모드로 전환 (T)",
     "toggle_sort": "정렬 방식 전환",
     "entry_actions": "파일 작업",
+    "loading": "로딩 중",
     "password_protected": "비밀번호 필요",
     "input_password": "비밀번호를 입력하세요",
     "sort": {
@@ -69,7 +73,8 @@
       "placeholder": "파일 검색...",
       "searching": "검색 중...",
       "search_help": "다음을 시도해 보세요:",
-      "no_result": "결과 없음"
+      "no_result": "결과 없음",
+      "results": "결과 {n}개"
     },
     "task_status_pending": "대기 중",
     "task_status_running": "실행 중",
@@ -448,6 +453,7 @@
       "next": "다음",
       "shuffle": "임의 재생",
       "repeat_one": "한 곡 반복",
+      "progress": "재생 위치",
       "volume": "볼륨",
       "mute": "음소거",
       "unmute": "음소거 해제",
@@ -458,6 +464,8 @@
       "desc": "동영상 재생",
       "play": "재생",
       "pause": "일시정지",
+      "progress": "재생 위치",
+      "volume": "볼륨",
       "mute": "음소거",
       "unmute": "음소거 해제",
       "fullscreen": "전체 화면",

--- a/web/src/i18n/lang/zh-CN.json
+++ b/web/src/i18n/lang/zh-CN.json
@@ -32,7 +32,9 @@
     },
     "text": {
       "yes": "是",
-      "no": "否"
+      "no": "否",
+      "alert_title": "提示",
+      "confirm_title": "确认"
     },
     "loading": {
       "cancel": "取消"
@@ -43,6 +45,7 @@
     "logout": "注销",
     "home": "主页",
     "admin": "管理员",
+    "skip_to_content": "跳到主要内容",
     "username": "用户名",
     "groups": "所属组",
     "file": "文件",
@@ -55,6 +58,7 @@
     "toggle_to_thumbnail": "切换到缩略图模式 (T)",
     "toggle_sort": "切换排序方式",
     "entry_actions": "文件操作",
+    "loading": "正在加载",
     "password_protected": "密码保护",
     "input_password": "请输入密码",
     "sort": {
@@ -69,7 +73,8 @@
       "placeholder": "搜索文件...",
       "searching": "搜索中...",
       "search_help": "试试:",
-      "no_result": "无结果"
+      "no_result": "无结果",
+      "results": "{n} 个结果"
     },
     "task_status_pending": "等待中",
     "task_status_running": "运行中",
@@ -448,6 +453,7 @@
       "next": "下一首",
       "shuffle": "随机播放",
       "repeat_one": "单曲循环",
+      "progress": "播放进度",
       "volume": "音量",
       "mute": "静音",
       "unmute": "取消静音",
@@ -458,6 +464,8 @@
       "desc": "播放视频",
       "play": "播放",
       "pause": "暂停",
+      "progress": "播放进度",
+      "volume": "音量",
       "mute": "静音",
       "unmute": "取消静音",
       "fullscreen": "全屏",

--- a/web/src/styles/index.scss
+++ b/web/src/styles/index.scss
@@ -84,6 +84,18 @@ a:focus-visible {
   width: 100%;
 }
 
+.visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
 img,
 picture,
 video,

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -73,5 +73,7 @@ export interface FormItem extends BaseFormItem {
   slot?: string
   labelSuffixSlot?: string
   placeholder?: I18nText
+  ariaLabel?: I18nText
+  autocomplete?: string
   validate?: (v: any) => PromiseValue<true | I18nText | undefined>
 }

--- a/web/src/utils/index.ts
+++ b/web/src/utils/index.ts
@@ -10,9 +10,12 @@ import { LocationQuery } from 'vue-router'
 export const IS_DEBUG = process.env.NODE_ENV === 'development'
 
 export function setTitle(title?: I18nText) {
-  if (title) title += ' - ' + window.___config___.appName
-  else title = window.___config___.appName
-  document.title = title.toString()
+  const pageTitle = title?.toString().trim() ?? ''
+  const appName = window.___config___.appName?.trim() ?? ''
+  document.title =
+    pageTitle && appName
+      ? `${pageTitle} - ${appName}`
+      : pageTitle || appName || 'go-drive'
 }
 
 export function formatTime(d: any) {

--- a/web/src/utils/ui-utils/input-dialog/InputDialog.vue
+++ b/web/src/utils/ui-utils/input-dialog/InputDialog.vue
@@ -6,6 +6,9 @@
       v-focus
       class="input-dialog__input"
       :placeholder="s(placeholder)"
+      :aria-label="inputLabel"
+      :aria-invalid="validationError ? 'true' : undefined"
+      :aria-describedby="validationError ? validationId : undefined"
       :disabled="!!loading"
     ></textarea>
     <input
@@ -15,9 +18,17 @@
       :type="opts.type || 'text'"
       class="input-dialog__input"
       :placeholder="s(placeholder)"
+      :aria-label="inputLabel"
+      :aria-invalid="validationError ? 'true' : undefined"
+      :aria-describedby="validationError ? validationId : undefined"
       :disabled="!!loading"
     />
-    <div v-if="validationError" class="input-dialog__validation">
+    <div
+      v-if="validationError"
+      :id="validationId"
+      class="input-dialog__validation"
+      role="alert"
+    >
       {{ validationError }}
     </div>
   </div>
@@ -25,7 +36,7 @@
 <script setup lang="ts">
 import { s } from '@/i18n'
 import { val } from '@/utils'
-import { ref, unref, watch } from 'vue'
+import { computed, ref, unref, watch } from 'vue'
 import { InputDialogOptions, InputDialogValidateFunc } from '.'
 
 const props = defineProps({
@@ -43,6 +54,10 @@ const emit = defineEmits<{ (e: 'loading', v?: boolean): void }>()
 
 const text = ref(props.opts.text || '')
 const placeholder = ref(props.opts.placeholder || '')
+const validationId = `input-dialog-validation-${Math.round(Math.random() * 1000000)}`
+const inputLabel = computed(() =>
+  s(props.opts.title || placeholder.value)
+)
 const multipleLine = ref(val(props.opts.multipleLine, false))
 const validationError = ref<string | null>('')
 

--- a/web/src/utils/ui-utils/loading-dialog/LoadingDialog.vue
+++ b/web/src/utils/ui-utils/loading-dialog/LoadingDialog.vue
@@ -1,5 +1,10 @@
 <template>
-  <DialogView v-model:show="showing" class="loading-dialog" transition="none">
+  <DialogView
+    v-model:show="showing"
+    class="loading-dialog"
+    transition="none"
+    :accessible-label="text || t('app.loading')"
+  >
     <div class="loading-dialog__content">
       <Icon class="loading-dialog__icon loading-icon" name="loading" />
       <span class="loading-dialog__text">{{ text }}</span>

--- a/web/src/utils/ui-utils/text-dialog/index.ts
+++ b/web/src/utils/ui-utils/text-dialog/index.ts
@@ -14,6 +14,7 @@ export function showAlertDialog(opts: TextDialogOptions | I18nText) {
   }
   return showBaseDialog<void>(TextDialog, {
     ...opts,
+    title: opts.title || T('dialog.text.alert_title'),
     transition: opts.transition || 'fade-scale-up',
   })
 }
@@ -24,6 +25,7 @@ export function showConfirmDialog(opts: TextDialogOptions | I18nText) {
   }
   return showBaseDialog<void>(TextDialog, {
     ...opts,
+    title: opts.title || T('dialog.text.confirm_title'),
     transition: opts.transition || 'fade-scale-up',
     confirmText: opts.confirmText || T('dialog.text.yes'),
     cancelText: opts.cancelText || T('dialog.text.no'),

--- a/web/src/views/Admin/ExtraDrives/index.vue
+++ b/web/src/views/Admin/ExtraDrives/index.vue
@@ -98,7 +98,11 @@
       </table>
     </div>
 
-    <DialogView v-model:show="edit.showing" fullscreen>
+    <DialogView
+      v-model:show="edit.showing"
+      fullscreen
+      :accessible-label="edit.name || $t('routes.title.extra_drives')"
+    >
       <div class="drive-script-editor-wrapper">
         <DriveCodeEditor
           v-if="edit.name"

--- a/web/src/views/Admin/index.vue
+++ b/web/src/views/Admin/index.vue
@@ -63,10 +63,13 @@ const currentMenu = computed(() => router.currentRoute.value.path)
 }
 
 .admin-page {
+  box-sizing: border-box;
   max-width: 1000px;
   margin: 16px auto 0;
   background-color: var(--color-bg-glass);
+  border: 1px solid var(--color-glass-border);
   border-radius: var(--radius-dialog);
+  outline: none;
   display: flex;
   overflow: hidden;
 
@@ -102,7 +105,12 @@ const currentMenu = computed(() => router.currentRoute.value.path)
   // pc
   .menu-list {
     width: 120px;
-    padding: 16px 0 42px;
+    border-radius:
+      calc(var(--radius-dialog) - 1px)
+      0
+      0
+      calc(var(--radius-dialog) - 1px);
+    overflow: hidden;
     border-right: solid 1px;
     border-color: var(--color-border);
   }
@@ -112,6 +120,22 @@ const currentMenu = computed(() => router.currentRoute.value.path)
       border-bottom: solid 1px;
       border-color: var(--color-border);
     }
+  }
+
+  .menu-item:first-child .menu-link {
+    border-radius: calc(var(--radius-dialog) - 1px) 0 0 0;
+  }
+
+  .menu-item:last-child .menu-link {
+    border-radius: 0 0 0 calc(var(--radius-dialog) - 1px);
+  }
+
+  .menu-item:only-child .menu-link {
+    border-radius:
+      calc(var(--radius-dialog) - 1px)
+      0
+      0
+      calc(var(--radius-dialog) - 1px);
   }
 
   .menu-content {
@@ -128,6 +152,11 @@ const currentMenu = computed(() => router.currentRoute.value.path)
     .menu-list {
       display: flex;
       width: 100%;
+      border-radius:
+        calc(var(--radius-dialog) - 1px)
+        calc(var(--radius-dialog) - 1px)
+        0
+        0;
       overflow-x: auto;
       overflow-y: hidden;
       border-bottom: solid 1px;
@@ -144,6 +173,22 @@ const currentMenu = computed(() => router.currentRoute.value.path)
 
     .menu-link {
       padding: 10px 16px;
+    }
+
+    .menu-item:first-child .menu-link {
+      border-radius: calc(var(--radius-dialog) - 1px) 0 0 0;
+    }
+
+    .menu-item:last-child .menu-link {
+      border-radius: 0 calc(var(--radius-dialog) - 1px) 0 0;
+    }
+
+    .menu-item:only-child .menu-link {
+      border-radius:
+        calc(var(--radius-dialog) - 1px)
+        calc(var(--radius-dialog) - 1px)
+        0
+        0;
     }
   }
 }

--- a/web/src/views/AppWrapper/index.vue
+++ b/web/src/views/AppWrapper/index.vue
@@ -1,5 +1,8 @@
 <template>
   <div class="app-wrapper">
+    <a class="skip-link" href="#main-content" @click.prevent="skipToContent">
+      {{ $t('app.skip_to_content') }}
+    </a>
     <header class="app-header" data-ui="app-header">
       <div class="user-area">
         <button
@@ -46,7 +49,10 @@
       </div>
     </header>
 
-    <RouterView />
+    <main id="main-content" ref="mainContentEl" tabindex="-1">
+      <h1 class="visually-hidden">{{ pageHeading }}</h1>
+      <RouterView />
+    </main>
 
     <!-- login dialog -->
     <DialogView
@@ -70,7 +76,7 @@ import LoginView from '@/views/Login/LoginView.vue'
 
 import { logout as logoutApi } from '@/api'
 import { alert, loading } from '@/utils/ui-utils'
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAppStore } from '@/store'
 import { useRouter } from 'vue-router'
@@ -79,6 +85,7 @@ import { EXPLORER_PATH_BASE } from '@/config'
 const router = useRouter()
 const store = useAppStore()
 const { t } = useI18n()
+const mainContentEl = ref<HTMLElement | null>(null)
 
 const loginDialogShowing = computed({
   get: () => store.showLogin,
@@ -89,6 +96,14 @@ const progressBarValue = computed(() => store.progressBar)
 
 const isLoggedIn = computed(() => !!user.value)
 const isAdmin = computed(() => store.isAdmin)
+const pageHeading = computed(() => {
+  const route = router.currentRoute.value
+  if (route.meta.title) return route.meta.title.toString()
+  if (typeof route.params.path === 'string' && route.params.path) {
+    return route.params.path
+  }
+  return window.___config___.appName || 'go-drive'
+})
 
 const navMenus = computed(() => {
   const menus = [{ name: t('app.home'), to: '/' }]
@@ -100,6 +115,10 @@ const navMenus = computed(() => {
 
 const login = () => {
   store.toggleLogin(true)
+}
+
+const skipToContent = () => {
+  mainContentEl.value?.focus()
 }
 
 const toIndexPage = () => {
@@ -154,6 +173,22 @@ const afterLogin = () => {
     .nav-button:not(:first-child) {
       margin-left: 16px;
     }
+  }
+}
+
+.skip-link {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  z-index: 10000;
+  padding: 8px 12px;
+  border-radius: var(--radius-control);
+  background: var(--color-bg-surface);
+  color: var(--color-text);
+  transform: translateY(-150%);
+
+  &:focus {
+    transform: translateY(0);
   }
 }
 

--- a/web/src/views/EntryExplorer/EntryMenu.vue
+++ b/web/src/views/EntryExplorer/EntryMenu.vue
@@ -8,21 +8,27 @@
       <EntryIcon :entry="(entry as Entry)" />
       <span class="entry-menu__entry-name">{{ (entry as Entry).name }}</span>
     </h2>
-    <ul class="entry-menu__menus">
+    <ul class="entry-menu__menus" role="menu">
       <li
         v-for="(m, i) in menus"
         :key="i"
-        class="entry-menu__menu-item"
-        :class="m.display.type && `entry-menu__menu-item-${m.display.type}`"
-        data-ui="menu-item"
-        :data-variant="m.display.type || 'default'"
-        :title="s(m.display.description)"
-        @click="emit('click', { entry, menu: m })"
+        role="none"
       >
-        <span class="entry-menu__icon">
-          <Icon v-if="m.display.icon" :name="m.display.icon" />
-        </span>
-        <span>{{ m.display.name }}</span>
+        <button
+          type="button"
+          class="entry-menu__menu-item"
+          :class="m.display.type && `entry-menu__menu-item-${m.display.type}`"
+          data-ui="menu-item"
+          :data-variant="m.display.type || 'default'"
+          role="menuitem"
+          :title="s(m.display.description)"
+          @click="emit('click', { entry, menu: m })"
+        >
+          <span class="entry-menu__icon">
+            <Icon v-if="m.display.icon" :name="m.display.icon" />
+          </span>
+          <span>{{ m.display.name }}</span>
+        </button>
       </li>
     </ul>
   </div>
@@ -95,13 +101,22 @@ const multiple = computed(() => Array.isArray(props.entry))
   user-select: none;
   overflow-x: hidden;
   overflow-y: auto;
+
+  > li {
+    list-style: none;
+  }
 }
 
 .entry-menu__menu-item {
   display: flex;
   align-items: center;
-  list-style-type: none;
+  width: 100%;
+  border: 0;
   padding: 0 20px;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
   cursor: pointer;
   transition:
     color var(--motion-duration-fast) var(--motion-easing-standard),
@@ -131,7 +146,7 @@ const multiple = computed(() => Array.isArray(props.entry))
 
 .entry-menu--compact {
   width: 220px;
-  padding: 8px 0;
+  padding: 0;
   border-radius: inherit;
 
   .entry-menu__entry {
@@ -145,6 +160,26 @@ const multiple = computed(() => Array.isArray(props.entry))
   .entry-menu__menu-item {
     min-height: 40px;
     padding: 0 12px;
+  }
+
+  .entry-menu__menus > li:first-child > .entry-menu__menu-item {
+    border-radius:
+      calc(var(--radius-popover) - 1px)
+      calc(var(--radius-popover) - 1px)
+      0
+      0;
+  }
+
+  .entry-menu__menus > li:last-child > .entry-menu__menu-item {
+    border-radius:
+      0
+      0
+      calc(var(--radius-popover) - 1px)
+      calc(var(--radius-popover) - 1px);
+  }
+
+  .entry-menu__menus > li:only-child > .entry-menu__menu-item {
+    border-radius: calc(var(--radius-popover) - 1px);
   }
 }
 

--- a/web/src/views/EntryExplorer/NewEntryArea.vue
+++ b/web/src/views/EntryExplorer/NewEntryArea.vue
@@ -543,9 +543,7 @@ onBeforeMount(() => {
   }
 
   .hidden-input-file {
-    position: fixed;
-    top: -200px;
-    left: -200px;
+    display: none;
   }
 }
 

--- a/web/src/views/EntryExplorer/SearchPanel/SearchItem.vue
+++ b/web/src/views/EntryExplorer/SearchPanel/SearchItem.vue
@@ -45,7 +45,7 @@ const itemClicked = (e: EntryEventData) => emit('click', e)
 <style lang="scss">
 .search-panel__item {
   margin: 0;
-  padding: 8px 0;
+  padding: 0;
   list-style-type: none;
   overflow: hidden;
 
@@ -53,7 +53,7 @@ const itemClicked = (e: EntryEventData) => emit('click', e)
     display: flex;
     color: var(--color-text);
     text-decoration: none;
-    padding: 0 16px;
+    padding: 8px 16px;
   }
 
   .entry-icon {

--- a/web/src/views/EntryExplorer/SearchPanel/index.vue
+++ b/web/src/views/EntryExplorer/SearchPanel/index.vue
@@ -5,6 +5,8 @@
     data-ui="search-panel"
     data-surface="glass"
     :class="{ active: showing }"
+    role="search"
+    @focusout="onFocusOut"
   >
     <div class="search-panel__search">
       <input
@@ -12,12 +14,19 @@
         v-model="queryInput"
         type="text"
         class="search-panel__search-input"
+        :aria-label="$t('app.search.placeholder')"
         :placeholder="$t('app.search.placeholder')"
         @input="onInput"
         @keydown.enter="triggerSearch"
         @keydown.stop
         @focus="onInputFocus"
       />
+      <span
+        class="visually-hidden"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+      >{{ searchStatus }}</span>
     </div>
     <div v-if="showing" class="search-panel__result" @scroll="onResultScroll">
       <div v-if="result.length === 0" class="search-panel__tip">
@@ -79,44 +88,69 @@ const searchError = ref('')
 const showing = ref(false)
 
 const searchExamples = computed(() => store.config?.search?.examples)
+const searchStatus = computed(() => {
+  if (searching.value) return t('app.search.searching')
+  if (searchError.value) return searchError.value
+  if (result.value.length > 0) {
+    return t('app.search.results', { n: result.value.length })
+  }
+  return ''
+})
+
+let searchGeneration = 0
+const pendingRequests = new Set<string>()
 
 const triggerSearch = () => {
+  const generation = ++searchGeneration
   result.value = []
+  searchError.value = ''
+  next.value = 0
   if (!q.value) {
+    searching.value = false
     return
   }
-  next.value = 0
-  doSearch()
+  void doSearch(generation)
 }
 
 const loadNextPage = debounce(() => {
-  if (next.value === -1) return
-  doSearch()
+  if (next.value === -1 || searching.value) return
+  void doSearch(searchGeneration)
 }, 100)
 
-const doSearch = async () => {
+const doSearch = async (generation: number) => {
+  const query = q.value
+  const cursor = next.value
+  const requestKey = `${generation}:${cursor}`
+  if (pendingRequests.has(requestKey)) return
+  pendingRequests.add(requestKey)
   searching.value = true
   searchError.value = ''
-  let res
   try {
-    res = await searchEntries(props.path, q.value, next.value)
+    const res = await searchEntries(props.path, query, cursor)
+    if (generation !== searchGeneration || query !== q.value) return
+    result.value.push(...res.items)
+    searchError.value =
+      res.items.length === 0 && result.value.length === 0
+        ? t('app.search.no_result')
+        : ''
+    next.value = res.next
   } catch (e: any) {
-    searchError.value = e.message
-    return
+    if (generation === searchGeneration && query === q.value) {
+      searchError.value = e.message
+    }
   } finally {
-    searching.value = false
+    pendingRequests.delete(requestKey)
+    if (generation === searchGeneration) searching.value = false
   }
-
-  result.value.push(...res.items)
-  searchError.value = res.items.length === 0 ? t('app.search.no_result') : ''
-  next.value = res.next
 }
 
 const reset = () => {
+  searchGeneration++
   queryInput.value = ''
   result.value = []
   next.value = 0
   searchError.value = ''
+  searching.value = false
 }
 
 const itemClicked = (e: EntryEventData) => {
@@ -132,9 +166,18 @@ const onInputFocus = () => {
   setActive(true)
 }
 
+const onFocusOut = (e: FocusEvent) => {
+  const next = e.relatedTarget as Node | null
+  if (next && thisEl.value?.contains(next)) return
+  if (result.value.length === 0) setActive(false)
+}
+
 const onResultScroll = (e: Event) => {
   const target = e.target as HTMLElement
-  if (target.scrollHeight - target.scrollTop - target.clientHeight < 100) {
+  if (
+    !searching.value &&
+    target.scrollHeight - target.scrollTop - target.clientHeight < 100
+  ) {
     loadNextPage()
   }
 }
@@ -146,11 +189,11 @@ const setActive = (active: boolean) => {
   else qEl.value?.blur()
   if (active && !eventAttached) {
     eventAttached = true
-    document.addEventListener('mousedown', onDocumentTouched)
+    document.addEventListener('pointerdown', onDocumentPointerDown)
   }
   if (!active && eventAttached) {
     eventAttached = false
-    document.removeEventListener('mousedown', onDocumentTouched)
+    document.removeEventListener('pointerdown', onDocumentPointerDown)
   }
 }
 
@@ -167,7 +210,7 @@ useHotKey(
   { el: () => qEl.value! }
 )
 
-const onDocumentTouched = (e: MouseEvent) => {
+const onDocumentPointerDown = (e: PointerEvent) => {
   let target = e.target as HTMLElement | null
   do {
     if (target === thisEl.value) break
@@ -178,6 +221,7 @@ const onDocumentTouched = (e: MouseEvent) => {
 }
 
 onUnmounted(() => {
+  searchGeneration++
   setActive(false)
 })
 
@@ -185,7 +229,10 @@ defineExpose({ setActive })
 </script>
 <style lang="scss">
 .search-panel {
+  box-sizing: border-box;
+  border: 1px solid var(--color-glass-border);
   border-radius: var(--radius-glass);
+  outline: none;
   transition: box-shadow var(--motion-duration-normal)
     var(--motion-easing-standard);
   background-color: var(--color-bg-glass);

--- a/web/src/views/EntryExplorer/index.vue
+++ b/web/src/views/EntryExplorer/index.vue
@@ -53,7 +53,7 @@
       <div
         v-if="entryMenuOverlayShowing"
         class="entry-menu-overlay"
-        @click.self="closeEntryMenu"
+        @click.self="closeEntryMenu()"
       >
         <Transition
           name="fade-slide-down"
@@ -67,6 +67,8 @@
             data-ui="menu"
             data-surface="glass"
             :style="entryMenuPosition"
+            @keydown="onEntryMenuKeydown"
+            @focusout="onEntryMenuFocusout"
           >
             <EntryMenu
               v-if="entryMenuData"
@@ -164,6 +166,7 @@ const entryMenuShowing = ref(false)
 const entryMenuOverlayShowing = ref(false)
 const entryMenuEl = ref<HTMLElement | null>(null)
 const entryMenuPosition = ref({ left: '0px', top: '0px' })
+let entryMenuTrigger: HTMLElement | null = null
 
 const { viewMode, sortBy, onViewModeChange, onSortByChange, filterFn } =
   useEntriesListState(currentDirEntry, user)
@@ -297,12 +300,56 @@ const onEntryClicked = ({ entry, event }: EntryEventData) => {
 }
 
 const onEntryMenuClicked = ({ entry, menu }: EntryMenuClickData) => {
-  closeEntryMenu()
+  closeEntryMenu(false)
   executeHandler(menu.name, entry)
 }
 
-const closeEntryMenu = () => {
+const closeEntryMenu = (restoreFocus = true) => {
   entryMenuShowing.value = false
+  if (restoreFocus) {
+    const trigger = entryMenuTrigger
+    nextTick(() => {
+      if (trigger && document.contains(trigger)) trigger.focus()
+    })
+  }
+}
+
+const getEntryMenuItems = () =>
+  Array.from(
+    entryMenuEl.value?.querySelectorAll<HTMLElement>('[role="menuitem"]') ?? []
+  )
+
+const onEntryMenuKeydown = (e: KeyboardEvent) => {
+  if (e.key === 'Escape') {
+    e.preventDefault()
+    e.stopPropagation()
+    closeEntryMenu()
+    return
+  }
+  const items = getEntryMenuItems()
+  if (!items.length) return
+  const activeIndex = items.indexOf(document.activeElement as HTMLElement)
+  let nextIndex: number | undefined
+  if (e.key === 'ArrowDown') nextIndex = (activeIndex + 1) % items.length
+  else if (e.key === 'ArrowUp') {
+    nextIndex = (activeIndex - 1 + items.length) % items.length
+  } else if (e.key === 'Home') nextIndex = 0
+  else if (e.key === 'End') nextIndex = items.length - 1
+  if (nextIndex !== undefined) {
+    e.preventDefault()
+    items[nextIndex].focus()
+  }
+}
+
+const onEntryMenuFocusout = (e: FocusEvent) => {
+  const next = e.relatedTarget
+  if (
+    next instanceof Node &&
+    entryMenuEl.value?.contains(next)
+  ) {
+    return
+  }
+  closeEntryMenu(false)
 }
 
 const positionEntryMenu = async (target: HTMLElement) => {
@@ -330,6 +377,7 @@ const positionEntryMenu = async (target: HTMLElement) => {
   top = Math.max(margin, top)
 
   entryMenuPosition.value = { left: `${left}px`, top: `${top}px` }
+  getEntryMenuItems()[0]?.focus()
 }
 
 const showEntryMenu = ({ entry, event }: EntryEventData) => {
@@ -355,6 +403,7 @@ const showEntryMenu = ({ entry, event }: EntryEventData) => {
   entryMenuShowing.value = true
   const target = event?.currentTarget
   if (target instanceof HTMLElement) {
+    entryMenuTrigger = target
     void positionEntryMenu(target)
   }
 }
@@ -511,7 +560,10 @@ window.addEventListener('keydown', onKeyDown)
 
 .entry-menu-popup {
   position: fixed;
+  box-sizing: border-box;
+  border: 1px solid var(--color-glass-border);
   border-radius: var(--radius-popover);
+  outline: none;
   overflow: hidden;
   box-shadow: var(--shadow-elevated);
 }

--- a/web/src/views/Login/LoginView.vue
+++ b/web/src/views/Login/LoginView.vue
@@ -36,6 +36,13 @@ const loginForm = computed<FormItem[]>(() => {
   const fields = (loginProvider.value?.form ?? []).map((item) => ({
     ...item,
     label: undefined,
+    ariaLabel: item.label,
+    autocomplete:
+      item.field === 'username'
+        ? 'username'
+        : item.field === 'password'
+          ? 'current-password'
+          : undefined,
     placeholder: item.placeholder || item.label,
     class: 'login-field',
   }))


### PR DESCRIPTION
## Summary

- make sort, entry-action, and new-item menus fully keyboard operable with reliable focus management
- add accessible media sliders, form errors, dialog names, progress state, page landmarks, and translated labels
- prevent stale search responses and duplicate pagination requests while announcing results to assistive technology

## Validation

- npm run lint
- npm run build-web
- go build -tags release
- Chrome keyboard and focus regression through the agent-sandbox CDP browser
- axe scans on root, file-list, and admin pages: 0 violations and 0 incomplete checks
- mobile 375x812: no horizontal overflow
- clean console, page-error, and HTTP 4xx/5xx checks on successful flows