### PR TITLE
feat(web): render login form from auth config

### DIFF
--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -151,12 +151,12 @@ export interface LoginResult {
   expiresAt: number
 }
 
-export function login(username: string, password: string) {
+export function login(provider: string, formData: Record<string, string>) {
   return http
-    .post<LoginResult>('/auth/identity/callback', {
-      username,
-      password,
-    })
+    .post<LoginResult>(
+      `/auth/${encodeURIComponent(provider)}/callback`,
+      formData
+    )
     .then((res) => {
       setToken(res.token)
       return res

--- a/web/src/components/Form/index.vue
+++ b/web/src/components/Form/index.vue
@@ -65,7 +65,10 @@ const idPrefix = `form-${Math.round(Math.random() * 1000000)}-`
 const data = ref<O>({})
 let fields: InstanceType<typeof FormItem>[] = []
 
-const emit = defineEmits<{ (e: 'update:modelValue', v: O): void }>()
+const emit = defineEmits<{
+  (e: 'update:modelValue', v: O): void
+  (e: 'submit', event: Event): void
+}>()
 
 const addFieldsRef = (el: Element | ComponentPublicInstance | null) => {
   if (el) fields.push(el as InstanceType<typeof FormItem>)
@@ -95,7 +98,10 @@ const clearError = () => {
 
 defineExpose({ validate, clearError })
 
-const onSubmit = (e: Event) => e.preventDefault()
+const onSubmit = (e: Event) => {
+  e.preventDefault()
+  emit('submit', e)
+}
 
 const emitInput = () => emit('update:modelValue', data.value)
 

--- a/web/src/types/model/config.ts
+++ b/web/src/types/model/config.ts
@@ -1,3 +1,5 @@
+import type { FormItem } from '..'
+
 export interface SearchConfig {
   enabled: boolean
   examples: string[]
@@ -13,7 +15,19 @@ export interface VersionConfig {
   version: string
 }
 
+export interface AuthProvider {
+  provider: string
+  displayName: string
+  type: 'form'
+  form: FormItem[]
+}
+
+export interface AuthConfig {
+  providers: AuthProvider[]
+}
+
 export interface Config {
+  auth: AuthConfig
   version: VersionConfig
   thumbnail: ThumbnailConfig
   options: O

--- a/web/src/views/Login/LoginView.vue
+++ b/web/src/views/Login/LoginView.vue
@@ -1,54 +1,53 @@
 <template>
   <div class="login-view">
-    <form action="" @submit="onSubmit">
-      <span class="form-item username">
-        <input
-          v-model="username"
-          v-focus
-          class="value"
-          type="text"
-          required
-          :placeholder="$t('p.login.username')"
-        />
-      </span>
-      <span class="form-item password">
-        <input
-          v-model="password"
-          class="value"
-          type="password"
-          required
-          :placeholder="$t('p.login.password')"
-        />
-      </span>
-      <span class="form-item submit">
-        <SimpleButton native-type="submit" class="submit" :loading="loading">
+    <SimpleForm
+      v-if="loginProvider"
+      :key="loginProvider.provider"
+      v-model="formData"
+      :form="loginForm"
+      @submit="onSubmit"
+    >
+      <template #submit>
+        <SimpleButton native-type="submit" :loading="loading">
           {{ $t('p.login.login') }}
         </SimpleButton>
-      </span>
-    </form>
+      </template>
+    </SimpleForm>
   </div>
 </template>
 <script setup lang="ts">
 import { login } from '@/api'
 import { useAppStore } from '@/store'
-import { User } from '@/types'
+import { AuthProvider, FormItem, User } from '@/types'
 import { alert } from '@/utils/ui-utils'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 
 const emit = defineEmits<{ (e: 'success', v?: User): void }>()
 
 const store = useAppStore()
 
-const username = ref('')
-const password = ref('')
+const loginProvider = computed<AuthProvider | undefined>(() =>
+  store.config?.auth.providers.find((provider) => provider.type === 'form')
+)
+const formData = ref<Record<string, string>>()
 const loading = ref(false)
 
-const onSubmit = async (e: Event) => {
-  e.preventDefault()
-  if (loading.value) return
+const loginForm = computed<FormItem[]>(() => {
+  const fields = (loginProvider.value?.form ?? []).map((item) => ({
+    ...item,
+    label: undefined,
+    placeholder: item.placeholder || item.label,
+    class: 'login-field',
+  }))
+  return [...fields, { slot: 'submit', class: 'submit' }]
+})
+
+const onSubmit = async () => {
+  const provider = loginProvider.value
+  if (!provider || loading.value) return
   loading.value = true
   try {
-    await login(username.value, password.value)
+    await login(provider.provider, formData.value ?? {})
     const user = await store.getUser()
     emit('success', user)
   } catch (e: any) {
@@ -60,30 +59,27 @@ const onSubmit = async (e: Event) => {
 </script>
 <style lang="scss">
 .login-view {
+  box-sizing: border-box;
   width: 300px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 16px 0;
+  padding: 16px;
 
-  .form-item {
+  .simple-form {
     display: block;
   }
 
-  .username {
-    margin-bottom: 0 !important;
+  .login-field,
+  .submit {
+    width: 100%;
+    padding-right: 0;
   }
 
-  .username input {
-    border-bottom: none !important;
-  }
-
-  .password {
-    margin-bottom: 16px;
+  .login-field {
+    margin-bottom: 8px;
   }
 
   .submit {
     text-align: right;
+    margin: 16px 0 0;
   }
 }
 </style>


### PR DESCRIPTION
## Summary

- render the login fields from the auth form descriptor returned by `/config`
- submit the collected form data to the callback for the returned provider
- reuse `SimpleForm`, with field labels presented as placeholders and balanced dialog padding
- keep local and LDAP authentication on the existing identity flow

## Validation

- `npm run lint`
- `npm run build-web`
- `go test ./server/auth ./server`
- manually verified the login dialog in a real browser
