### PR TITLE
feat(drive): support custom request headers

### DIFF
--- a/common/req/headers.go
+++ b/common/req/headers.go
@@ -1,0 +1,91 @@
+package req
+
+import (
+	"encoding/json"
+	err "go-drive/common/errors"
+	"go-drive/common/i18n"
+	"go-drive/common/types"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"golang.org/x/net/http/httpguts"
+)
+
+const RequestHeadersField = "request_headers"
+
+const (
+	requestHeaderItemKey    = "header"
+	requestHeaderNameField  = "name"
+	requestHeaderValueField = "value"
+)
+
+type requestHeaderConfig struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+var unsupportedRequestHeaders = map[string]struct{}{
+	"connection":          {},
+	"content-length":      {},
+	"host":                {},
+	"keep-alive":          {},
+	"proxy-authenticate":  {},
+	"proxy-authorization": {},
+	"proxy-connection":    {},
+	"te":                  {},
+	"trailer":             {},
+	"transfer-encoding":   {},
+	"upgrade":             {},
+}
+
+// RequestHeadersForm returns the form schema consumed by ParseRequestHeaders.
+func RequestHeadersForm(label, description string) types.FormItem {
+	return types.FormItem{
+		Field: RequestHeadersField, Label: label, Type: "form",
+		Description: description,
+		Forms: &types.FormItemForms{
+			AddText: i18n.T("request_headers.add"),
+			Forms: []types.FormItemForm{{
+				Key: requestHeaderItemKey,
+				Form: []types.FormItem{
+					{Field: requestHeaderNameField, Label: i18n.T("request_headers.name"), Type: "text", Required: true},
+					{Field: requestHeaderValueField, Label: i18n.T("request_headers.value"), Type: "text"},
+				},
+			}},
+		},
+	}
+}
+
+// ParseRequestHeaders parses the repeatable request-header form value.
+func ParseRequestHeaders(value string) (http.Header, error) {
+	if strings.TrimSpace(value) == "" {
+		return nil, nil
+	}
+
+	items := []requestHeaderConfig{}
+	if e := json.Unmarshal([]byte(value), &items); e != nil {
+		return nil, err.NewBadRequestError(i18n.T("request_headers.invalid_format", e.Error()))
+	}
+
+	headers := make(http.Header, len(items))
+	for i, item := range items {
+		name := strings.TrimSpace(item.Name)
+		if !httpguts.ValidHeaderFieldName(name) {
+			return nil, err.NewBadRequestError(i18n.T("request_headers.invalid_name", strconv.Itoa(i+1), name))
+		}
+		if _, unsupported := unsupportedRequestHeaders[strings.ToLower(name)]; unsupported {
+			return nil, err.NewBadRequestError(i18n.T("request_headers.unsupported", name))
+		}
+		if !httpguts.ValidHeaderFieldValue(item.Value) {
+			return nil, err.NewBadRequestError(i18n.T("request_headers.invalid_value", name))
+		}
+
+		name = http.CanonicalHeaderKey(name)
+		if _, exists := headers[name]; exists {
+			return nil, err.NewBadRequestError(i18n.T("request_headers.duplicate", name))
+		}
+		headers.Set(name, item.Value)
+	}
+	return headers, nil
+}

--- a/common/req/headers_test.go
+++ b/common/req/headers_test.go
@@ -1,0 +1,87 @@
+package req
+
+import (
+	err "go-drive/common/errors"
+	"go-drive/common/i18n"
+	"testing"
+)
+
+func TestRequestHeadersFormSchema(t *testing.T) {
+	form := RequestHeadersForm("Request Headers", "Request header description")
+	if form.Field != RequestHeadersField || form.Type != "form" {
+		t.Fatalf("unexpected top-level form: %#v", form)
+	}
+	if form.Label != "Request Headers" || form.Description != "Request header description" {
+		t.Fatalf("unexpected top-level text: %#v", form)
+	}
+	if form.Forms == nil || len(form.Forms.Forms) != 1 {
+		t.Fatalf("unexpected nested forms: %#v", form.Forms)
+	}
+	item := form.Forms.Forms[0]
+	if item.Key != requestHeaderItemKey || item.Name != "" || len(item.Form) != 2 {
+		t.Fatalf("unexpected header item form: %#v", item)
+	}
+	if item.Form[0].Field != requestHeaderNameField || !item.Form[0].Required {
+		t.Fatalf("unexpected header name field: %#v", item.Form[0])
+	}
+	if item.Form[1].Field != requestHeaderValueField {
+		t.Fatalf("unexpected header value field: %#v", item.Form[1])
+	}
+	translations := map[string]string{
+		form.Forms.AddText: "request_headers.add",
+		item.Form[0].Label: "request_headers.name",
+		item.Form[1].Label: "request_headers.value",
+	}
+	for token, want := range translations {
+		parts, e := i18n.UnmarshalT(token)
+		if e != nil || len(parts) == 0 || parts[0] != want {
+			t.Fatalf("translation token %q: parts=%#v error=%v, want key %q", token, parts, e, want)
+		}
+	}
+}
+
+func TestParseRequestHeaders(t *testing.T) {
+	headers, e := ParseRequestHeaders(`[
+		{"$key":"header","name":" User-Agent ","value":"rclone/v1.68.0"},
+		{"$key":"header","name":"X-Data-Space","value":"capsule"}
+	]`)
+	if e != nil {
+		t.Fatalf("ParseRequestHeaders: %v", e)
+	}
+	if got := headers.Get("User-Agent"); got != "rclone/v1.68.0" {
+		t.Fatalf("User-Agent = %q", got)
+	}
+	if got := headers.Get("X-Data-Space"); got != "capsule" {
+		t.Fatalf("X-Data-Space = %q", got)
+	}
+}
+
+func TestParseRequestHeadersRejectsInvalidInput(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		key   string
+	}{
+		{name: "invalid json", value: `{`, key: "request_headers.invalid_format"},
+		{name: "empty name", value: `[{"name":"","value":"x"}]`, key: "request_headers.invalid_name"},
+		{name: "invalid name", value: `[{"name":"Bad Header","value":"x"}]`, key: "request_headers.invalid_name"},
+		{name: "invalid value", value: `[{"name":"X-Test","value":"a\nb"}]`, key: "request_headers.invalid_value"},
+		{name: "unsupported", value: `[{"name":"Content-Length","value":"10"}]`, key: "request_headers.unsupported"},
+		{name: "duplicate", value: `[{"name":"X-Test","value":"a"},{"name":"x-test","value":"b"}]`, key: "request_headers.duplicate"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, e := ParseRequestHeaders(tt.value)
+			if e == nil {
+				t.Fatal("expected an error")
+			}
+			if _, ok := e.(err.BadRequestError); !ok {
+				t.Fatalf("error type = %T, want errors.BadRequestError", e)
+			}
+			parts, parseError := i18n.UnmarshalT(e.Error())
+			if parseError != nil || len(parts) == 0 || parts[0] != tt.key {
+				t.Fatalf("error token: parts=%#v error=%v, want key %q", parts, parseError, tt.key)
+			}
+		})
+	}
+}

--- a/common/types/common.go
+++ b/common/types/common.go
@@ -48,7 +48,7 @@ type FormItemPathOptions struct {
 
 type FormItemForm struct {
 	Key  string     `json:"key"`
-	Name string     `json:"name" i18n:""`
+	Name string     `json:"name,omitempty" i18n:""`
 	Form []FormItem `json:"form"`
 }
 

--- a/docs/lang/en-US.yml
+++ b/docs/lang/en-US.yml
@@ -5,6 +5,15 @@ error:
   fail_ban_message: Too many failures, please try again later
 util:
   request_failed: "[{{ 1 }}] Request failed"
+request_headers:
+  add: Add Header
+  name: Name
+  value: Value
+  invalid_format: "Invalid request headers: {{ 1 }}"
+  invalid_name: "Invalid request header name at item {{ 1 }}: '{{ 2 }}'"
+  unsupported: "Request header '{{ 1 }}' is not configurable"
+  invalid_value: "Invalid value for request header '{{ 1 }}'"
+  duplicate: "Duplicate request header '{{ 1 }}'"
 oauth:
   state_mismatch: state does not match
 search:
@@ -167,6 +176,9 @@ drive:
       proxy_out:
         label: Proxy Download
         description: Download files through server proxy
+      request_headers:
+        label: Request Headers
+        description: Headers added to requests sent by the go-drive server. Direct browser uploads and downloads do not include them; enable the corresponding proxy option if the storage service requires these headers for file transfers. Configured values override existing headers, while S3 signing may replace headers it controls.
       cache_ttl:
         label: CacheTTL
         description: Cache time to live, if omitted, no cache. Valid time units are 'ms', 's', 'm', 'h'.
@@ -184,6 +196,9 @@ drive:
       password:
         label: Password
         description: ""
+      request_headers:
+        label: Request Headers
+        description: Headers added to requests sent to the remote WebDAV server. Configured values override operation-specific headers; configured Basic Auth replaces Authorization last.
       cache_ttl:
         label: CacheTTL
         description: Cache time to live, if omitted, no cache. Valid time units are 'ms', 's', 'm', 'h'.

--- a/docs/lang/ko-KR.yml
+++ b/docs/lang/ko-KR.yml
@@ -5,6 +5,15 @@ error:
   fail_ban_message: 실패 횟수가 너무 많습니다. 잠시 후 다시 시도해 주세요
 util:
   request_failed: "[{{ 1 }}] 요청이 실패했습니다"
+request_headers:
+  add: 요청 헤더 추가
+  name: 이름
+  value: 값
+  invalid_format: "요청 헤더 형식이 잘못되었습니다: {{ 1 }}"
+  invalid_name: "{{ 1 }}번째 항목의 요청 헤더 이름이 잘못되었습니다: '{{ 2 }}'"
+  unsupported: "요청 헤더 '{{ 1 }}'은(는) 설정할 수 없습니다"
+  invalid_value: "요청 헤더 '{{ 1 }}'의 값이 잘못되었습니다"
+  duplicate: "요청 헤더 '{{ 1 }}'이(가) 중복되었습니다"
 oauth:
   state_mismatch: state 값이 일치하지 않습니다
 search:
@@ -167,6 +176,9 @@ drive:
       proxy_out:
         label: 다운로드 프록시
         description: 서버 프록시를 통해 파일을 다운로드합니다
+      request_headers:
+        label: 사용자 지정 요청 헤더
+        description: go-drive 서버가 보내는 요청에 추가할 헤더입니다. 브라우저 직접 업로드 및 다운로드에는 포함되지 않습니다. 스토리지 서비스가 파일 전송에 이 헤더를 요구하면 해당 프록시 옵션을 활성화하세요. 설정값은 기존 헤더를 덮어쓰지만 S3 서명 과정에서 관리하는 헤더는 다시 대체될 수 있습니다.
       cache_ttl:
         label: 캐시 TTL
         description: "캐시 유지 시간이며, 생략하면 캐시를 사용하지 않습니다. 사용 가능한 시간 단위는 'ms', 's', 'm', 'h'입니다."
@@ -184,6 +196,9 @@ drive:
       password:
         label: 비밀번호
         description: ""
+      request_headers:
+        label: 사용자 지정 요청 헤더
+        description: 원격 WebDAV 서버로 보내는 모든 요청에 추가할 헤더입니다. 설정값은 작업별 헤더를 덮어쓰며, 설정된 Basic Auth는 마지막에 Authorization을 대체합니다.
       cache_ttl:
         label: 캐시 TTL
         description: "캐시 유지 시간이며, 생략하면 캐시를 사용하지 않습니다. 사용 가능한 시간 단위는 'ms', 's', 'm', 'h'입니다."

--- a/docs/lang/zh-CN.yml
+++ b/docs/lang/zh-CN.yml
@@ -5,6 +5,15 @@ error:
   fail_ban_message: 失败次数过多，请稍后再试
 util:
   request_failed: "[{{ 1 }}] 请求失败"
+request_headers:
+  add: 添加请求头
+  name: 名称
+  value: 值
+  invalid_format: "自定义请求头格式无效: {{ 1 }}"
+  invalid_name: "第 {{ 1 }} 项的请求头名称无效: '{{ 2 }}'"
+  unsupported: "不支持配置请求头 '{{ 1 }}'"
+  invalid_value: "请求头 '{{ 1 }}' 的值无效"
+  duplicate: "请求头 '{{ 1 }}' 重复"
 oauth:
   state_mismatch: state 不匹配
 search:
@@ -167,6 +176,9 @@ drive:
       proxy_out:
         label: 下载代理
         description: 下载时是否经过服务器代理
+      request_headers:
+        label: 自定义请求头
+        description: 添加到 go-drive 服务端所发请求的请求头。浏览器直传和直下不会携带这些请求头；如果存储服务要求文件传输请求必须携带它们，请开启对应的代理选项。配置值会覆盖已有请求头，但 S3 签名流程可能再次覆盖其控制的请求头。
       cache_ttl:
         label: 缓存生命周期
         description: 有效单位为 'ms', 's', 'm', 'h', 如果省略则没有缓存
@@ -184,6 +196,9 @@ drive:
       password:
         label: 密码
         description: ""
+      request_headers:
+        label: 自定义请求头
+        description: 添加到发往远端 WebDAV 服务的全部请求。配置值会覆盖具体操作生成的请求头；已配置的 Basic Auth 最后覆盖 Authorization。
       cache_ttl:
         label: 缓存生命周期
         description: 有效单位为 'ms', 's', 'm', 'h', 如果省略则没有缓存

--- a/docs/site/drives/s3.md
+++ b/docs/site/drives/s3.md
@@ -17,9 +17,18 @@ Use this Drive with AWS S3 and compatible services such as COS, OSS, and MinIO.
 | Endpoint | API address for a compatible service; may be left empty for AWS depending on the environment |
 | Path style | Uses `endpoint/bucket/key`; often required by MinIO and similar services |
 | Proxy upload/download | Forces file contents through go-drive |
+| Request headers | Additional headers for requests sent by the go-drive server |
 | Cache TTL | Entry cache time |
 
 The credentials need at least permission to list, read, write, copy, and delete objects in the target bucket. Create a dedicated least-privilege account for go-drive.
+
+## Custom request headers
+
+Use **Request headers** for S3-compatible services that require an identifying header such as a custom `User-Agent`. The headers are added only when go-drive sends an HTTP request to the storage service. They are not included in presigned URLs and do not change direct-transfer behavior.
+
+When proxy upload or download is disabled, that file transfer is performed by the browser and does not include the configured headers. Enable the corresponding proxy option if the storage service requires them on upload or download requests.
+
+Configured values override headers generated earlier in request construction. S3 signing runs afterward and may replace headers it controls, such as `Authorization`. Connection-specific headers such as `Host` and `Content-Length` cannot be configured. Header values are stored and returned as ordinary Drive configuration; they are not secret-masked.
 
 ## CORS for direct browser transfers
 

--- a/docs/site/drives/webdav.md
+++ b/docs/site/drives/webdav.md
@@ -14,8 +14,13 @@ This page describes using another WebDAV service as a storage backend. To let cl
 | URL | WebDAV root URL, optionally including a remote path prefix |
 | Username | Basic Auth username; may be empty |
 | Password | Basic Auth password; may be empty |
+| Request headers | Additional headers sent to the remote WebDAV service |
 | Cache TTL | Directory-entry cache time; zero or below disables caching |
 
 Example: `https://dav.example.com/remote.php/dav/files/alice/`. The path in the URL becomes the remote root of this Drive.
+
+Custom request headers are sent with every remote WebDAV request and override operation-specific values such as `Depth`, `Destination`, `Range`, and `Content-Type`. When a username is configured, go-drive applies Basic Auth afterward, replacing a custom `Authorization` header; without a username, custom `Authorization` is preserved. Connection-specific headers such as `Host` and `Content-Length` cannot be configured.
+
+Header values are stored and returned as ordinary Drive configuration; they are not secret-masked. Use HTTPS when a header contains credentials or other sensitive data.
 
 File copies and moves within the same Drive use WebDAV `COPY` / `MOVE`; the operation fails if the remote service does not support it. Directory copies are usually performed recursively by go-drive. HTTPS is recommended to avoid transmitting Basic Auth credentials in plaintext.

--- a/docs/site/zh-CN/drives/s3.md
+++ b/docs/site/zh-CN/drives/s3.md
@@ -3,7 +3,7 @@ title: S3 兼容对象存储
 description: 在 go-drive 中配置 AWS S3、MinIO、COS、OSS 等 S3 兼容存储，包括 endpoint、region 和 CORS。
 lang: zh-CN
 translation_key: drive-s3
-source_hash: 79e9f153d222d47bac9ee2ffb01a5884a6cf2166d96c786ca4d292ee2e34b83e
+source_hash: 871208ad4eb89f535b4422bb257f29b82126b9cc01170c03a2ba7b37c7687d08
 ---
 
 # S3 兼容对象存储
@@ -18,9 +18,18 @@ source_hash: 79e9f153d222d47bac9ee2ffb01a5884a6cf2166d96c786ca4d292ee2e34b83e
 | Endpoint | 兼容服务的 API 地址；AWS 可按环境留空 |
 | Path style | 使用 `endpoint/bucket/key`，MinIO 等服务常需开启 |
 | 代理上传/下载 | 强制内容经过 go-drive |
+| 自定义请求头 | 添加到 go-drive 服务端所发请求的额外请求头 |
 | 缓存 TTL | 条目缓存时间 |
 
 凭据至少需要目标桶的列举、读取、写入、复制和删除对象权限。建议为 go-drive 创建专用最小权限账号。
+
+## 自定义请求头
+
+部分 S3 兼容服务要求客户端携带标识请求头，例如自定义 `User-Agent`，此时可使用“自定义请求头”。这些请求头仅在 go-drive 向存储服务发出 HTTP 请求时添加，不会写入预签名 URL，也不会改变直传行为。
+
+关闭上传或下载代理时，对应的文件传输由浏览器完成，不会携带这里配置的请求头。如果存储服务要求上传或下载请求必须携带它们，请开启对应的代理选项。
+
+配置值会覆盖请求构造过程中较早生成的请求头。S3 签名在其后执行，可能再次覆盖 `Authorization` 等由签名流程控制的请求头。不能配置 `Host`、`Content-Length` 等连接控制请求头。请求头值会作为普通 Drive 配置存储和返回，不会进行秘密遮罩。
 
 ## 浏览器直传的 CORS
 

--- a/docs/site/zh-CN/drives/webdav.md
+++ b/docs/site/zh-CN/drives/webdav.md
@@ -3,7 +3,7 @@ title: WebDAV 存储 Drive
 description: 将远端 WebDAV 服务器挂载为 go-drive 存储后端，并配置 URL、账号、根路径和目录缓存。
 lang: zh-CN
 translation_key: drive-webdav
-source_hash: 4157bee30f16f21f5f4ab76f9d633a72ac992756e121b002e1b6fd4c09732029
+source_hash: 13d5ec641043caa11e0d7c0fa60ba98a194eb1cbe77869c5433028ebe47ca6f1
 ---
 
 # WebDAV 存储 Drive
@@ -15,8 +15,13 @@ source_hash: 4157bee30f16f21f5f4ab76f9d633a72ac992756e121b002e1b6fd4c09732029
 | URL | WebDAV 根 URL，可包含远端路径前缀 |
 | 用户名 | Basic Auth 用户名，可留空 |
 | 密码 | Basic Auth 密码，可留空 |
+| 自定义请求头 | 发往远端 WebDAV 服务的额外请求头 |
 | 缓存 TTL | 目录项缓存时间；不大于零关闭缓存 |
 
 示例：`https://dav.example.com/remote.php/dav/files/alice/`。URL 中的路径会作为该 Drive 的远端根路径。
+
+自定义请求头会随每个远端 WebDAV 请求发出，并覆盖 `Depth`、`Destination`、`Range`、`Content-Type` 等具体操作生成的值。配置用户名时，go-drive 会在其后应用 Basic Auth，覆盖自定义 `Authorization`；未配置用户名时则保留自定义 `Authorization`。不能配置 `Host`、`Content-Length` 等连接控制请求头。
+
+请求头值会作为普通 Drive 配置存储和返回，不会进行秘密遮罩。请求头包含凭据或其他敏感数据时请使用 HTTPS。
 
 同一 Drive 内的文件复制和移动使用 WebDAV `COPY` / `MOVE`；远端服务不支持时操作会失败。目录复制通常由 go-drive 递归执行。推荐 HTTPS，避免 Basic Auth 凭据明文传输。

--- a/drive/s3/index.go
+++ b/drive/s3/index.go
@@ -7,6 +7,7 @@ import (
 	"go-drive/common/driveutil"
 	err "go-drive/common/errors"
 	"go-drive/common/i18n"
+	"go-drive/common/req"
 	"go-drive/common/task"
 	"go-drive/common/types"
 	"go-drive/common/utils"
@@ -41,6 +42,10 @@ func init() {
 			{Field: "endpoint", Label: s3T("form.endpoint.label"), Type: "text", Description: s3T("form.endpoint.description")},
 			{Field: "proxy_upload", Label: s3T("form.proxy_in.label"), Type: "checkbox", Description: s3T("form.proxy_in.description")},
 			{Field: "proxy_download", Label: s3T("form.proxy_out.label"), Type: "checkbox", Description: s3T("form.proxy_out.description")},
+			req.RequestHeadersForm(
+				s3T("form.request_headers.label"),
+				s3T("form.request_headers.description"),
+			),
 			{Field: "cache_ttl", Label: s3T("form.cache_ttl.label"), Type: "text", Description: s3T("form.cache_ttl.description")},
 		},
 		Factory: driveutil.DriveFactory{Create: NewDrive},
@@ -70,6 +75,10 @@ func NewDrive(ctx context.Context, config types.SM,
 	region := config["region"]
 	endpoint := config["endpoint"]
 	cacheTtl := config.GetDuration("cache_ttl", -1)
+	requestHeaders, e := req.ParseRequestHeaders(config[req.RequestHeadersField])
+	if e != nil {
+		return nil, e
+	}
 
 	s3Cfg, e := awsCfg.LoadDefaultConfig(ctx,
 		awsCfg.WithRegion(region),
@@ -79,6 +88,7 @@ func NewDrive(ctx context.Context, config types.SM,
 	if e != nil {
 		return nil, e
 	}
+	s3Cfg.APIOptions = append(s3Cfg.APIOptions, withRequestHeaders(requestHeaders))
 	client := s3.NewFromConfig(s3Cfg, func(o *s3.Options) { o.UsePathStyle = pathStyle != "" })
 
 	d := &Drive{
@@ -442,7 +452,11 @@ func (s *Drive) Upload(ctx context.Context, path string, size int64,
 }
 
 func (s *Drive) newPresign() *s3.PresignClient {
-	return s3.NewPresignClient(s.c, s3.WithPresignExpires(2*time.Hour))
+	return s3.NewPresignClient(
+		s.c,
+		s3.WithPresignExpires(2*time.Hour),
+		s3.WithPresignClientFromClientOptions(withoutRequestHeaders),
+	)
 }
 
 func buildCompleteUploadBody(etag string) []awsType.CompletedPart {

--- a/drive/s3/index_test.go
+++ b/drive/s3/index_test.go
@@ -1,0 +1,71 @@
+package s3
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"go-drive/common/driveutil"
+	"go-drive/common/types"
+)
+
+func TestRequestHeadersApplyOnlyToServerRequests(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		if got := r.Header.Get("User-Agent"); got != "rclone/v1.68.0" {
+			t.Errorf("User-Agent = %q", got)
+		}
+		if got := r.Header.Get("X-Data-Space"); got != "capsule" {
+			t.Errorf("X-Data-Space = %q", got)
+		}
+		if authorization := strings.ToLower(r.Header.Get("Authorization")); !strings.Contains(authorization, "x-data-space") {
+			t.Errorf("custom header was not included in the server request signature: %q", authorization)
+		}
+		if authorization := r.Header.Get("Authorization"); strings.HasPrefix(authorization, "Bearer ") {
+			t.Errorf("configured Authorization was not replaced by S3 signing: %q", authorization)
+		}
+		if got := r.Header.Get("X-Amz-Date"); got == "ignored" || got == "" {
+			t.Errorf("configured X-Amz-Date was not replaced by S3 signing: %q", got)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	drive, e := NewDrive(context.Background(), types.SM{
+		"id":         "access-key",
+		"secret":     "secret-key",
+		"bucket":     "bucket",
+		"path_style": "1",
+		"region":     "us-east-1",
+		"endpoint":   server.URL,
+		"request_headers": `[
+			{"$key":"header","name":"User-Agent","value":"rclone/v1.68.0"},
+			{"$key":"header","name":"X-Data-Space","value":"capsule"},
+			{"$key":"header","name":"Authorization","value":"Bearer ignored"},
+			{"$key":"header","name":"X-Amz-Date","value":"ignored"}
+		]`,
+	}, driveutil.DriveUtils{})
+	if e != nil {
+		t.Fatalf("NewDrive: %v", e)
+	}
+
+	upload, e := drive.Upload(context.Background(), "file.txt", 1, true, nil)
+	if e != nil {
+		t.Fatalf("Upload: %v", e)
+	}
+	presigned, e := url.Parse(upload.Config["url"])
+	if e != nil {
+		t.Fatalf("parse presigned URL: %v", e)
+	}
+	if signed := strings.ToLower(presigned.Query().Get("X-Amz-SignedHeaders")); strings.Contains(signed, "x-data-space") {
+		t.Fatalf("custom header unexpectedly signed into direct upload URL: %q", signed)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("server requests = %d, want only the initial HeadBucket request", got)
+	}
+}

--- a/drive/s3/utils.go
+++ b/drive/s3/utils.go
@@ -1,10 +1,57 @@
 package s3
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/smithy-go/middleware"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 )
+
+type requestHeadersMiddleware struct {
+	headers http.Header
+}
+
+const requestHeadersMiddlewareID = "go-drive:RequestHeaders"
+
+func (*requestHeadersMiddleware) ID() string {
+	return requestHeadersMiddlewareID
+}
+
+func (m *requestHeadersMiddleware) HandleBuild(ctx context.Context, in middleware.BuildInput,
+	next middleware.BuildHandler) (middleware.BuildOutput, middleware.Metadata, error) {
+	request, ok := in.Request.(*smithyhttp.Request)
+	if !ok {
+		return middleware.BuildOutput{}, middleware.Metadata{}, fmt.Errorf("unknown transport type %T", in.Request)
+	}
+	for name, values := range m.headers {
+		request.Header.Del(name)
+		for _, value := range values {
+			request.Header.Add(name, value)
+		}
+	}
+	return next.HandleBuild(ctx, in)
+}
+
+func withRequestHeaders(headers http.Header) func(*middleware.Stack) error {
+	return func(stack *middleware.Stack) error {
+		if len(headers) == 0 {
+			return nil
+		}
+		return stack.Build.Add(&requestHeadersMiddleware{headers: headers.Clone()}, middleware.After)
+	}
+}
+
+// withoutRequestHeaders explicitly removes custom headers from presigned
+// requests because direct browser transfers do not send them.
+func withoutRequestHeaders(o *s3.Options) {
+	o.APIOptions = append(o.APIOptions, func(stack *middleware.Stack) error {
+		stack.Build.Remove(requestHeadersMiddlewareID)
+		return nil
+	})
+}
 
 // withContentMD5 is a helper function to add content MD5 to the S3 request
 // see https://github.com/aws/aws-sdk-go-v2/discussions/2960

--- a/drive/webdav/index.go
+++ b/drive/webdav/index.go
@@ -30,6 +30,10 @@ func init() {
 			{Field: "url", Label: davT("form.url.label"), Type: "text", Required: true, Description: davT("form.url.description")},
 			{Field: "username", Label: davT("form.username.label"), Type: "text", Description: davT("form.username.description")},
 			{Field: "password", Label: davT("form.password.label"), Type: "password", Description: davT("form.password.description")},
+			req.RequestHeadersForm(
+				davT("form.request_headers.label"),
+				davT("form.request_headers.description"),
+			),
 			{Field: "cache_ttl", Label: davT("form.cache_ttl.label"), Type: "text", Description: davT("form.cache_ttl.description")},
 		},
 		Factory: driveutil.DriveFactory{Create: NewDrive},
@@ -42,6 +46,10 @@ func NewDrive(ctx context.Context, config types.SM,
 	u := config["url"]
 	username := config["username"]
 	password := config["password"]
+	requestHeaders, e := req.ParseRequestHeaders(config[req.RequestHeadersField])
+	if e != nil {
+		return nil, e
+	}
 
 	cacheTtl := config.GetDuration("cache_ttl", -1)
 
@@ -52,7 +60,7 @@ func NewDrive(ctx context.Context, config types.SM,
 	pathPrefix := uu.Path
 
 	w := &Drive{
-		username: username, password: password,
+		username: username, password: password, requestHeaders: requestHeaders,
 		cacheTTL: cacheTtl, pathPrefix: strings.TrimRight(pathPrefix, "/"),
 	}
 
@@ -79,9 +87,10 @@ func NewDrive(ctx context.Context, config types.SM,
 var _ types.IDrive = (*Drive)(nil)
 
 type Drive struct {
-	pathPrefix string
-	username   string
-	password   string
+	pathPrefix     string
+	username       string
+	password       string
+	requestHeaders http.Header
 
 	cacheTTL time.Duration
 	cache    driveutil.DriveCache
@@ -247,6 +256,12 @@ func (w *Drive) Upload(ctx context.Context, path string, size int64,
 }
 
 func (w *Drive) beforeRequest(req *http.Request) error {
+	for name, values := range w.requestHeaders {
+		req.Header.Del(name)
+		for _, value := range values {
+			req.Header.Add(name, value)
+		}
+	}
 	if w.username != "" {
 		req.SetBasicAuth(w.username, w.password)
 	}

--- a/drive/webdav/index_test.go
+++ b/drive/webdav/index_test.go
@@ -1,0 +1,55 @@
+package webdav
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go-drive/common/driveutil"
+	"go-drive/common/types"
+)
+
+func TestRequestHeadersApplyToWebDAVRequests(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("User-Agent"); got != "rclone/v1.68.0" {
+			t.Errorf("User-Agent = %q", got)
+		}
+		if got := r.Header.Get("X-Data-Space"); got != "capsule" {
+			t.Errorf("X-Data-Space = %q", got)
+		}
+		if got := r.Header.Get("Depth"); got != "9" {
+			t.Errorf("Depth = %q, want configured value", got)
+		}
+		wantAuthorization := "Basic " + base64.StdEncoding.EncodeToString([]byte("user:password"))
+		if got := r.Header.Get("Authorization"); got != wantAuthorization {
+			t.Errorf("Authorization = %q, want configured Basic credentials", got)
+		}
+		w.Header().Set("Content-Type", "application/xml")
+		w.WriteHeader(http.StatusMultiStatus)
+		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="utf-8"?>
+			<multistatus xmlns="DAV:">
+				<response>
+					<href>/</href>
+					<propstat><prop><resourcetype><collection/></resourcetype></prop></propstat>
+				</response>
+			</multistatus>`))
+	}))
+	defer server.Close()
+
+	_, e := NewDrive(context.Background(), types.SM{
+		"url":      server.URL,
+		"username": "user",
+		"password": "password",
+		"request_headers": `[
+			{"$key":"header","name":"User-Agent","value":"rclone/v1.68.0"},
+			{"$key":"header","name":"X-Data-Space","value":"capsule"},
+			{"$key":"header","name":"Depth","value":"9"},
+			{"$key":"header","name":"Authorization","value":"Bearer ignored"}
+		]`,
+	}, driveutil.DriveUtils{})
+	if e != nil {
+		t.Fatalf("NewDrive: %v", e)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/crypto v0.52.0
 	golang.org/x/image v0.43.0
+	golang.org/x/net v0.55.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/text v0.38.0
 	google.golang.org/api v0.254.0
@@ -96,7 +97,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.uber.org/mock v0.6.0 // indirect
 	golang.org/x/arch v0.22.0 // indirect
-	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect
 	google.golang.org/grpc v1.82.1 // indirect

--- a/server/api_admin_drives_test.go
+++ b/server/api_admin_drives_test.go
@@ -1,12 +1,39 @@
 package server
 
 import (
+	"encoding/json"
 	"errors"
 	"go-drive/common/driveutil"
 	"go-drive/common/types"
 	"reflect"
 	"testing"
 )
+
+func TestEscapeDriveConfigLeavesRequestHeadersVisible(t *testing.T) {
+	requestHeaders := `[{"$key":"header","name":"User-Agent","value":"rclone/v1.68.0"}]`
+	config, e := json.Marshal(types.SM{
+		"password":        "password value",
+		"request_headers": requestHeaders,
+	})
+	if e != nil {
+		t.Fatal(e)
+	}
+
+	escaped := escapeDriveConfigSecrets([]types.FormItem{
+		{Field: "password", Type: "password"},
+		{Field: "request_headers", Type: "form"},
+	}, string(config))
+	got := types.SM{}
+	if e = json.Unmarshal([]byte(escaped), &got); e != nil {
+		t.Fatal(e)
+	}
+	if got["password"] != secretPlaceholder {
+		t.Fatalf("password = %q", got["password"])
+	}
+	if got["request_headers"] != requestHeaders {
+		t.Fatalf("request_headers = %q", got["request_headers"])
+	}
+}
 
 func TestEscapeDriveInitConfigSecrets(t *testing.T) {
 	config := &driveutil.DriveInitConfig{

--- a/web/monaco-editor/package-lock.json
+++ b/web/monaco-editor/package-lock.json
@@ -643,9 +643,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -663,9 +660,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -683,9 +677,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -703,9 +694,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -723,9 +711,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -743,9 +728,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -937,6 +919,7 @@
       "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1126,6 +1109,7 @@
       "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -1691,9 +1675,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1715,9 +1696,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1739,9 +1717,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1763,9 +1738,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2148,6 +2120,7 @@
       "integrity": "sha512-t+YPtOQHpGW1QWsh1CHQ5cPIr9lbbGZLZnbihP/D/qZj/yuV68m8qarcV17nvkOX81BCrvzAlq2klCQFZghyTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -2237,6 +2210,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2277,6 +2251,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
## Summary

- Add a shared request-header form and parser with localized validation.
- Apply configured headers to server-side S3 and WebDAV requests while preserving Basic Auth and SigV4 signing precedence.
- Exclude custom headers from S3 presigned browser transfers and simplify single-option nested form additions.
- Update translations, documentation, and tests.

## Validation

- Focused Go tests passed.
- Web lint and build-web passed.
- Documentation translation and build checks passed.

Refs #181