### PR TITLE
style(web): standardize button variants

### DIFF
--- a/web/src/components/DialogView/index.vue
+++ b/web/src/components/DialogView/index.vue
@@ -34,18 +34,15 @@
           <slot name="header">
             <span>{{ title }}</span>
           </slot>
-          <button
+          <SimpleButton
             v-if="closeable"
-            type="button"
-            class="dialog-view__close-button plain-button"
-            data-ui="button"
-            data-variant="plain"
+            class="dialog-view__close-button"
+            variant="plain"
+            icon="close"
             :title="closeLabel"
             :aria-label="closeLabel"
             @click="closeButtonClicked"
-          >
-            <Icon name="close" aria-hidden="true" />
-          </button>
+          />
         </div>
         <div class="dialog-view__body" data-ui="dialog-body">
           <slot />
@@ -329,7 +326,7 @@ onBeforeUnmount(() => {
   padding: 16px 48px 16px 16px;
 }
 
-.dialog-view__close-button {
+.dialog-view__close-button.simple-button {
   position: absolute;
   top: 50%;
   transform: translateY(-50%);

--- a/web/src/components/Form/FormItem.vue
+++ b/web/src/components/Form/FormItem.vue
@@ -163,15 +163,16 @@
           :aria-describedby="error ? errorId : undefined"
           @input="textInput"
         />
-        <button
+        <SimpleButton
           v-if="!(disabled || item.disabled)"
           class="form-item--type-path-select"
-          data-ui="button"
+          variant="plain"
+          small
+          icon="folder"
           :title="$t('form.select_path')"
+          :aria-label="$t('form.select_path')"
           @click="selectPath"
-        >
-          <Icon name="folder" />
-        </button>
+        />
       </div>
       <FormItemForm
         v-if="item.type === 'form'"
@@ -432,7 +433,7 @@ const checkboxesInput = (optionValue: string, checked: boolean) => {
     padding-right: 28px !important;
   }
 
-  &-select {
+  &-select.simple-button.plain {
     position: absolute;
     top: 0;
     bottom: 0;

--- a/web/src/components/Form/FormItemForm.vue
+++ b/web/src/components/Form/FormItemForm.vue
@@ -3,17 +3,19 @@
     <div v-for="(f, i) in value" :key="i" class="form-item__form-item">
       <template v-if="formsMapByKey[f.typeKey]">
         <div class="form-item__form-item-title">
-          <span class="title-text"
-            >{{ i + 1 }}. {{ formsMapByKey[f.typeKey].name }}</span
-          >
-          <button
-            class="close-button plain-button small"
-            data-ui="button"
-            data-variant="plain"
+          <span class="title-text">
+            {{ i + 1 }}<template v-if="formsMapByKey[f.typeKey].name"
+              >. {{ formsMapByKey[f.typeKey].name }}</template
+            >
+          </span>
+          <SimpleButton
+            class="close-button"
+            variant="plain"
+            small
+            icon="close"
+            :aria-label="t('dialog.base.close')"
             @click="removeItem(i)"
-          >
-            <Icon name="close" />
-          </button>
+          />
         </div>
         <Form
           ref="formsEl"
@@ -24,19 +26,29 @@
         />
       </template>
     </div>
-    <div v-if="!disabled && addable">
+    <div v-if="!disabled && addable && forms.forms.length">
       <SimpleDropdown
+        v-if="forms.forms.length > 1"
         position="bottom-right"
         :aria-label="forms.addText?.toString()"
         :items="forms.forms"
         menu-max-height="100px"
+        trigger-class="simple-button small outline"
         @select="addForm"
       >
-        <span class="form-item__form-add">
-          <Icon name="add" aria-hidden="true" />
-          <span>{{ forms.addText }}</span>
-        </span>
+        <Icon name="add" aria-hidden="true" />
+        <span>{{ forms.addText }}</span>
       </SimpleDropdown>
+      <SimpleButton
+        v-else
+        small
+        variant="outline"
+        icon="add"
+        :aria-label="forms.addText?.toString()"
+        @click="addForm(forms.forms[0].key)"
+      >
+        {{ forms.addText }}
+      </SimpleButton>
     </div>
   </div>
 </template>
@@ -181,20 +193,9 @@ defineExpose({ validate })
     flex: 1;
   }
 
-  .close-button {
+  .close-button.simple-button {
     margin-left: auto;
   }
-}
-
-.form-item__form-add {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  border-radius: var(--radius-control);
-  padding: 4px 10px;
-  background-color: var(--color-accent-strong);
-  color: var(--color-on-accent);
-  line-height: 20px;
 }
 
 </style>

--- a/web/src/components/HandlerTitleBar.vue
+++ b/web/src/components/HandlerTitleBar.vue
@@ -6,16 +6,15 @@
     <span class="handler-title-bar-text" :title="props.title"
       ><slot>{{ props.title }}</slot></span
     >
-    <button
+    <SimpleButton
       v-if="closeable"
-      class="handler-title-bar-close plain-button"
-      data-ui="button"
-      data-variant="plain"
+      class="handler-title-bar-close"
+      variant="plain"
+      icon="close"
       title="Close"
+      aria-label="Close"
       @click="emit('close')"
-    >
-      <Icon name="close" />
-    </button>
+    />
   </h1>
 </template>
 <script setup lang="ts">
@@ -61,7 +60,7 @@ const emit = defineEmits<{ (e: 'close'): void }>()
   align-items: center;
 }
 
-.handler-title-bar-close {
+.handler-title-bar-close.simple-button {
   margin-left: auto;
 }
 </style>

--- a/web/src/components/SimpleButton/SimpleButton.vue
+++ b/web/src/components/SimpleButton/SimpleButton.vue
@@ -1,9 +1,9 @@
 <template>
   <button
     class="simple-button"
-    :class="{ loading, [type!]: !!type, small }"
+    :class="{ loading, [type!]: !!type, [variant!]: !!variant, small }"
     data-ui="button"
-    :data-variant="type || 'primary'"
+    :data-variant="variant === 'plain' ? 'plain' : type || 'primary'"
     :data-size="small ? 'compact' : 'default'"
     :disabled="!!loading || disabled"
     :type="nativeType"
@@ -21,7 +21,11 @@
   </button>
 </template>
 <script setup lang="ts">
-import type { SimpleButtonType, SimpleButtonNativeType } from '.'
+import type {
+  SimpleButtonType,
+  SimpleButtonVariant,
+  SimpleButtonNativeType,
+} from '.'
 import type { IconName } from '@/components/icons'
 import LoadingIndicator from '@/components/LoadingIndicator.vue'
 
@@ -31,6 +35,10 @@ defineProps({
   },
   type: {
     type: String as PropType<SimpleButtonType>,
+  },
+  variant: {
+    type: String as PropType<SimpleButtonVariant>,
+    default: 'solid',
   },
   small: {
     type: Boolean,
@@ -88,11 +96,48 @@ const emit = defineEmits<{ (e: 'click', event: MouseEvent): void }>()
     opacity: 0.86;
   }
 
+  &.outline {
+    border: 1px solid var(--color-accent);
+    background-color: transparent;
+    color: var(--color-accent);
+  }
+
+  &.plain {
+    margin: 0;
+    border: 0;
+    border-radius: 0;
+    padding: 0;
+    background-color: transparent;
+    color: var(--color-text);
+    font: inherit;
+    font-size: 28px;
+    text-decoration: none;
+  }
+
+  &.plain.small {
+    font-size: 16px;
+  }
+
+  &.plain:hover {
+    box-shadow: none;
+  }
+
   $types: ('info', 'success', 'warning', 'danger');
   @each $type in $types {
     &.#{$type} {
       background-color: var(--color-#{$type}-strong);
       color: var(--color-on-#{$type});
+    }
+
+    &.#{$type}.outline {
+      border-color: var(--color-#{$type}-strong);
+      background-color: transparent;
+      color: var(--color-#{$type}-strong);
+    }
+
+    &.#{$type}.plain {
+      background-color: transparent;
+      color: var(--color-#{$type}-strong);
     }
   }
 }

--- a/web/src/components/SimpleButton/index.ts
+++ b/web/src/components/SimpleButton/index.ts
@@ -2,6 +2,8 @@ import SimpleButton from './SimpleButton.vue'
 
 export type SimpleButtonType = 'info' | 'success' | 'warning' | 'danger'
 
+export type SimpleButtonVariant = 'solid' | 'outline' | 'plain'
+
 export type SimpleButtonNativeType = 'submit' | 'reset' | 'button'
 
 export default SimpleButton

--- a/web/src/components/SimpleDropdown.vue
+++ b/web/src/components/SimpleDropdown.vue
@@ -9,7 +9,7 @@
     <button
       ref="triggerEl"
       type="button"
-      class="simple-dropdown__trigger"
+      :class="['simple-dropdown__trigger', triggerClass]"
       data-ui="dropdown-trigger"
       aria-haspopup="menu"
       :aria-label="ariaLabel"
@@ -99,6 +99,9 @@ const props = defineProps({
     type: String,
   },
   menuMaxHeight: {
+    type: String,
+  },
+  triggerClass: {
     type: String,
   },
 })
@@ -324,6 +327,9 @@ onBeforeUnmount(() => {
   display: inline-flex;
   align-items: center;
   cursor: pointer;
+}
+
+.simple-dropdown__trigger:not(.simple-button) {
   padding: 0;
   border: 0;
   border-radius: 2px;

--- a/web/src/components/entry/EntryList.vue
+++ b/web/src/components/entry/EntryList.vue
@@ -14,19 +14,23 @@
         @drop="onDrop"
       />
       <div v-if="showToggles" class="entry-list__toggles">
-        <button
-          class="plain-button view-model-toggle"
-          data-ui="button"
-          data-variant="plain"
+        <SimpleButton
+          class="view-model-toggle"
+          variant="plain"
+          small
+          :icon="validViewMode === 'list' ? 'grid' : 'list'"
           :title="
             validViewMode === 'list'
               ? $t('app.toggle_to_thumbnail')
               : $t('app.toggle_to_list')
           "
+          :aria-label="
+            validViewMode === 'list'
+              ? $t('app.toggle_to_thumbnail')
+              : $t('app.toggle_to_list')
+          "
           @click="toggleViewMode"
-        >
-          <Icon :name="validViewMode === 'list' ? 'grid' : 'list'" />
-        </button>
+        />
         <SimpleDropdown
           :aria-label="$t('app.toggle_sort')"
           :items="sortModes"
@@ -96,18 +100,15 @@
             @icon-click="iconClicked(entry, $event)"
           />
         </EntryLink>
-        <button
+        <SimpleButton
           v-if="showMenuButton"
-          class="entry-list__menu-button plain-button"
-          data-ui="button"
-          data-variant="plain"
-          type="button"
+          class="entry-list__menu-button"
+          variant="plain"
+          icon="menu-dots"
           :title="$t('app.entry_actions')"
           :aria-label="$t('app.entry_actions')"
           @click="entryMenuClicked(entry, $event)"
-        >
-          <Icon name="menu-dots" />
-        </button>
+        />
       </li>
     </ul>
     <div v-if="sortedEntries.length === 0" class="entry-list__empty">
@@ -456,7 +457,7 @@ defineExpose({
     color: var(--color-text-muted);
   }
 
-  .view-model-toggle {
+  .view-model-toggle.simple-button {
     cursor: pointer;
     font-size: 16px;
   }
@@ -563,7 +564,7 @@ defineExpose({
   background-color: var(--color-bg-surface);
 }
 
-.entry-list__menu-button {
+.entry-list__menu-button.simple-button.plain {
   position: absolute;
   right: 12px;
   top: 50%;

--- a/web/src/handlers/audio/AudioView.vue
+++ b/web/src/handlers/audio/AudioView.vue
@@ -59,10 +59,9 @@
 
       <div class="audio-player__controls">
         <div class="audio-player__controls-side audio-player__controls-left">
-          <button
-            class="audio-player__btn plain-button"
-            data-ui="button"
-            data-variant="plain"
+          <SimpleButton
+            class="audio-player__btn"
+            variant="plain"
             :class="{ 'is-active': shuffle }"
             :title="$t('handler.audio.shuffle')"
             :aria-pressed="shuffle"
@@ -82,11 +81,10 @@
                 d="M18.5 4.5 22 7l-3.5 2.5zM18.5 14.5 22 17l-3.5 2.5z"
               />
             </svg>
-          </button>
-          <button
-            class="audio-player__btn plain-button"
-            data-ui="button"
-            data-variant="plain"
+          </SimpleButton>
+          <SimpleButton
+            class="audio-player__btn"
+            variant="plain"
             :class="{ 'is-active': repeatOne }"
             :title="$t('handler.audio.repeat_one')"
             :aria-pressed="repeatOne"
@@ -98,14 +96,13 @@
                 d="M7 7h10v3l4-4-4-4v3H5v6h2V7zm10 10H7v-3l-4 4 4 4v-3h12v-6h-2v4zm-4-2V9h-1l-2 1v1h1.5v4H13z"
               />
             </svg>
-          </button>
+          </SimpleButton>
         </div>
 
         <div class="audio-player__controls-center">
-          <button
-            class="audio-player__btn plain-button"
-            data-ui="button"
-            data-variant="plain"
+          <SimpleButton
+            class="audio-player__btn"
+            variant="plain"
             :title="$t('handler.audio.prev')"
             @click="prev"
           >
@@ -115,12 +112,11 @@
                 d="M6 6h2v12H6V6zm3.5 6l8.5 6V6l-8.5 6z"
               />
             </svg>
-          </button>
+          </SimpleButton>
 
-          <button
-            class="audio-player__btn audio-player__btn--play plain-button"
-            data-ui="button"
-            data-variant="plain"
+          <SimpleButton
+            class="audio-player__btn audio-player__btn--play"
+            variant="plain"
             :title="
               playing ? $t('handler.audio.pause') : $t('handler.audio.play')
             "
@@ -132,26 +128,24 @@
             <svg v-else viewBox="0 0 24 24" class="audio-player__icon">
               <path fill="currentColor" d="M8 5v14l11-7L8 5z" />
             </svg>
-          </button>
+          </SimpleButton>
 
-          <button
-            class="audio-player__btn plain-button"
-            data-ui="button"
-            data-variant="plain"
+          <SimpleButton
+            class="audio-player__btn"
+            variant="plain"
             :title="$t('handler.audio.next')"
             @click="next"
           >
             <svg viewBox="0 0 24 24" class="audio-player__icon">
               <path fill="currentColor" d="M16 6h2v12h-2V6zM6 6l8.5 6L6 18V6z" />
             </svg>
-          </button>
+          </SimpleButton>
         </div>
 
         <div class="audio-player__volume audio-player__controls-side">
-          <button
-            class="audio-player__btn plain-button"
-            data-ui="button"
-            data-variant="plain"
+          <SimpleButton
+            class="audio-player__btn"
+            variant="plain"
             :title="muted ? $t('handler.audio.unmute') : $t('handler.audio.mute')"
             @click="toggleMute"
           >
@@ -171,7 +165,7 @@
                 d="M3 9v6h4l5 5V4L7 9H3zm13.5 3a4.5 4.5 0 00-2.5-4v8a4.5 4.5 0 002.5-4zM14 3.2v2.1a7 7 0 010 13.4v2.1a9 9 0 000-17.6z"
               />
             </svg>
-          </button>
+          </SimpleButton>
           <div
             ref="volumeEl"
             class="audio-player__volume-bar"
@@ -647,7 +641,7 @@ onUnmounted(() => {
     gap: 6px;
   }
 
-  &__btn {
+  &__btn.simple-button.plain {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -675,7 +669,7 @@ onUnmounted(() => {
     height: 22px;
   }
 
-  &__btn--play {
+  &__btn--play.simple-button.plain {
     width: 52px;
     height: 52px;
     background-color: var(--color-accent-strong);

--- a/web/src/handlers/download/DownloadView.vue
+++ b/web/src/handlers/download/DownloadView.vue
@@ -7,14 +7,13 @@
   >
     <h1 class="page-title">
       <span>{{ $t('hv.download.download') }}</span>
-      <button
-        class="plain-button close-button"
-        data-ui="button"
-        data-variant="plain"
+      <SimpleButton
+        class="close-button"
+        variant="plain"
+        icon="close"
+        :aria-label="$t('dialog.base.close')"
         @click="emit('close')"
-      >
-        <Icon name="close" />
-      </button>
+      />
     </h1>
     <div class="page-content">
       <template v-if="singleEntry">

--- a/web/src/handlers/video/VideoView.vue
+++ b/web/src/handlers/video/VideoView.vue
@@ -70,10 +70,9 @@
       </div>
 
       <div class="video-controls__row">
-        <button
-          class="video-controls__btn plain-button"
-          data-ui="button"
-          data-variant="plain"
+        <SimpleButton
+          class="video-controls__btn"
+          variant="plain"
           :title="
             playing ? $t('handler.video.pause') : $t('handler.video.play')
           "
@@ -85,7 +84,7 @@
           <svg v-else viewBox="0 0 24 24" class="video-controls__icon">
             <path fill="currentColor" d="M8 5v14l11-7L8 5z" />
           </svg>
-        </button>
+        </SimpleButton>
 
         <span class="video-controls__time">
           {{ formatTime(currentTime) }} / {{ formatTime(duration) }}
@@ -94,10 +93,9 @@
         <span class="video-controls__spacer" />
 
         <div class="video-controls__volume">
-          <button
-            class="video-controls__btn plain-button"
-            data-ui="button"
-            data-variant="plain"
+          <SimpleButton
+            class="video-controls__btn"
+            variant="plain"
             :title="
               muted
                 ? $t('handler.video.unmute')
@@ -121,7 +119,7 @@
                 d="M3 9v6h4l5 5V4L7 9H3zm13.5 3a4.5 4.5 0 00-2.5-4v8a4.5 4.5 0 002.5-4zM14 3.2v2.1a7 7 0 010 13.4v2.1a9 9 0 000-17.6z"
               />
             </svg>
-          </button>
+          </SimpleButton>
           <div
             ref="volumeEl"
             class="video-controls__volume-bar"
@@ -148,11 +146,10 @@
           </div>
         </div>
 
-        <button
+        <SimpleButton
           v-if="supportsPip"
-          class="video-controls__btn plain-button"
-          data-ui="button"
-          data-variant="plain"
+          class="video-controls__btn"
+          variant="plain"
           :title="$t('handler.video.pip')"
           @click="togglePip"
         >
@@ -162,12 +159,11 @@
               d="M19 11h-8v6h8v-6zm4 8V4.98C23 3.88 22.1 3 21 3H3c-1.1 0-2 .88-2 1.98V19c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2zm-2 .02H3V4.97h18v14.05z"
             />
           </svg>
-        </button>
+        </SimpleButton>
 
-        <button
-          class="video-controls__btn plain-button"
-          data-ui="button"
-          data-variant="plain"
+        <SimpleButton
+          class="video-controls__btn"
+          variant="plain"
           :title="
             isFullscreen
               ? $t('handler.video.exit_fullscreen')
@@ -191,7 +187,7 @@
               d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"
             />
           </svg>
-        </button>
+        </SimpleButton>
       </div>
     </div>
   </div>
@@ -444,7 +440,7 @@ onUnmounted(() => {
     .handler-title-bar-text {
       color: #fff;
     }
-    .handler-title-bar-close {
+    .handler-title-bar-close.simple-button.plain {
       color: #fff;
     }
   }
@@ -569,7 +565,7 @@ onUnmounted(() => {
     margin-top: 2px;
   }
 
-  &__btn {
+  &__btn.simple-button.plain {
     display: flex;
     align-items: center;
     justify-content: center;

--- a/web/src/styles/index.scss
+++ b/web/src/styles/index.scss
@@ -61,6 +61,92 @@
 
 .markdown-body {
   background-color: transparent;
+  color: var(--color-text);
+
+  h1,
+  h2 {
+    border-bottom-color: var(--color-border);
+  }
+
+  mark {
+    background-color: var(--color-bg-attention);
+    color: var(--color-text);
+  }
+
+  code,
+  tt {
+    background-color: var(--color-bg-hover);
+    color: var(--color-text);
+  }
+
+  .highlight pre,
+  pre {
+    background-color: var(--color-field-bg);
+    border: solid 1px var(--color-border);
+    color: var(--color-text);
+    -webkit-backdrop-filter: var(--backdrop-filter-field);
+    backdrop-filter: var(--backdrop-filter-field);
+  }
+
+  pre code,
+  pre tt {
+    background-color: transparent;
+    border: 0;
+  }
+
+  kbd {
+    background-color: var(--color-bg-hover);
+    color: var(--color-text);
+    border-color: var(--color-border);
+    box-shadow: inset 0 -1px 0 var(--color-border);
+  }
+
+  table {
+    background-color: transparent;
+  }
+
+  table tr {
+    background-color: transparent;
+    border-top-color: var(--color-border);
+  }
+
+  table tr:nth-child(2n) {
+    background-color: var(--color-bg-hover);
+  }
+
+  table td,
+  table th {
+    background-color: transparent;
+    border-color: var(--color-border);
+  }
+
+  table th {
+    background-color: var(--color-bg-table-header);
+  }
+
+  blockquote {
+    border-left-color: var(--color-border);
+  }
+
+  hr {
+    background-color: var(--color-border);
+  }
+
+  span.frame {
+    border-color: var(--color-border);
+  }
+
+  .csv-data .blob-num {
+    background-color: transparent;
+  }
+
+  .csv-data th {
+    background-color: var(--color-bg-table-header);
+  }
+
+  .footnotes {
+    border-top-color: var(--color-border);
+  }
 }
 
 // Nicer keyboard-focus ring for buttons and links using the theme primary

--- a/web/src/styles/markdown-dark.scss
+++ b/web/src/styles/markdown-dark.scss
@@ -19,28 +19,4 @@
     }
   }
 
-  .highlight pre,
-  pre {
-    background-color: var(--color-bg-elevated);
-  }
-
-  kbd {
-    background-color: var(--color-bg-elevated);
-    color: var(--color-text);
-    border-color: var(--color-border);
-  }
-
-  table td,
-  table th {
-    background-color: var(--color-bg-elevated);
-    border-color: var(--color-border);
-  }
-
-  blockquote {
-    border-left-color: var(--color-border);
-  }
-
-  hr {
-    background-color: var(--color-bg-elevated);
-  }
 }

--- a/web/src/styles/themes/dark.scss
+++ b/web/src/styles/themes/dark.scss
@@ -4,21 +4,23 @@ $theme-dark: (
   color-bg-surface: #1d2026,
   color-bg-elevated: #252931,
   color-bg-glass: rgba(37, 41, 49, 0.58),
-  color-bg-hover: #2d333b,
-  color-bg-focus: #343b45,
-  color-bg-selected: #183f65,
-  color-bg-invalid: #4c2429,
-  color-bg-table-header: #282c34,
+  // Interaction backgrounds are overlays so custom page backgrounds remain visible.
+  color-bg-hover: rgba(255, 255, 255, 0.08),
+  color-bg-focus: rgba(88, 166, 255, 0.18),
+  color-bg-selected: rgba(31, 111, 235, 0.28),
+  color-bg-attention: rgba(227, 179, 65, 0.22),
+  color-bg-invalid: rgba(218, 54, 51, 0.22),
+  color-bg-table-header: rgba(255, 255, 255, 0.04),
 
   // Content and separators.
   color-text: #f0f3f6,
   color-text-muted: #a8b3c2,
   color-text-disabled: #8c959f,
-  color-border: #3d444d,
+  color-border: rgba(255, 255, 255, 0.16),
   color-field-bg: rgba(37, 41, 49, 0.48),
   color-field-bg-disabled: rgba(48, 54, 61, 0.64),
-  color-field-border: #57606a,
-  color-glass-border: rgba(255, 255, 255, 0.2),
+  color-field-border: rgba(255, 255, 255, 0.28),
+  color-glass-border: rgba(255, 255, 255, 0.22),
 
   // Interactive and status colors. Filled controls deliberately use darker
   // variants so their foreground contrast remains stable in the dark theme.

--- a/web/src/styles/themes/default.scss
+++ b/web/src/styles/themes/default.scss
@@ -4,21 +4,23 @@ $theme-default: (
   color-bg-surface: #ffffff,
   color-bg-elevated: #ffffff,
   color-bg-glass: rgba(255, 255, 255, 0.62),
-  color-bg-hover: #f0f2f5,
-  color-bg-focus: #e9eef5,
-  color-bg-selected: #dbeafe,
-  color-bg-invalid: #fee2e2,
-  color-bg-table-header: #eef1f4,
+  // Interaction backgrounds are overlays so custom page backgrounds remain visible.
+  color-bg-hover: rgba(31, 35, 40, 0.08),
+  color-bg-focus: rgba(9, 105, 218, 0.1),
+  color-bg-selected: rgba(9, 105, 218, 0.16),
+  color-bg-attention: rgba(154, 103, 0, 0.18),
+  color-bg-invalid: rgba(207, 34, 46, 0.1),
+  color-bg-table-header: rgba(31, 35, 40, 0.04),
 
   // Content and separators.
   color-text: #1f2328,
   color-text-muted: #59636e,
   color-text-disabled: #6e7781,
-  color-border: #d8dee6,
+  color-border: rgba(31, 35, 40, 0.16),
   color-field-bg: rgba(255, 255, 255, 0.46),
   color-field-bg-disabled: rgba(240, 242, 245, 0.62),
-  color-field-border: #b8c0cc,
-  color-glass-border: rgba(255, 255, 255, 0.92),
+  color-field-border: rgba(31, 35, 40, 0.28),
+  color-glass-border: rgba(255, 255, 255, 0.72),
 
   // Interactive and status colors. The "strong" variants are intended for
   // filled controls; the base variants work as text/icon colors.

--- a/web/src/views/Admin/ExtraDrives/DriveCodeEditor.vue
+++ b/web/src/views/Admin/ExtraDrives/DriveCodeEditor.vue
@@ -15,14 +15,13 @@
       <SimpleButton :loading="saving" :disabled="loading" @click="onSave">{{
         $t('p.admin.extra_drive.save')
       }}</SimpleButton>
-      <button
-        class="plain-button close-button"
-        data-ui="button"
-        data-variant="plain"
+      <SimpleButton
+        class="close-button"
+        variant="plain"
+        icon="close"
+        :aria-label="$t('dialog.base.close')"
         @click="emit('close')"
-      >
-        <Icon name="close" />
-      </button>
+      />
     </div>
     <div class="drive-code-editors">
       <CodeEditor

--- a/web/src/views/AppWrapper/index.vue
+++ b/web/src/views/AppWrapper/index.vue
@@ -5,15 +5,14 @@
     </a>
     <header class="app-header" data-ui="app-header">
       <div class="user-area">
-        <button
+        <SimpleButton
           v-if="!isLoggedIn"
-          class="plain-button small"
-          data-ui="button"
-          data-variant="plain"
+          variant="plain"
+          small
           @click="login"
         >
           {{ $t('app.login') }}
-        </button>
+        </SimpleButton>
 
         <RouterLink
           v-for="m in navMenus"
@@ -37,14 +36,13 @@
             "
             >{{ user!.username }}</span
           >
-          <button
-            class="plain-button small"
-            data-ui="button"
-            data-variant="plain"
+          <SimpleButton
+            variant="plain"
+            small
             @click="logout"
           >
             {{ $t('app.logout') }}
-          </button>
+          </SimpleButton>
         </span>
       </div>
     </header>

--- a/web/src/views/EntryExplorer/TaskManager/TaskItem.vue
+++ b/web/src/views/EntryExplorer/TaskManager/TaskItem.vue
@@ -38,46 +38,38 @@
       >{{ statusText }}</span
     >
     <span class="upload-task-item__ops">
-      <button
+      <SimpleButton
         v-if="showStart"
-        class="plain-button"
-        data-ui="button"
-        data-variant="plain"
+        variant="plain"
+        icon="play"
         :title="t('p.task.start')"
+        :aria-label="t('p.task.start')"
         @click="emit('start')"
-      >
-        <Icon name="play" />
-      </button>
-      <button
+      />
+      <SimpleButton
         v-if="showPause"
-        class="plain-button"
-        data-ui="button"
-        data-variant="plain"
+        variant="plain"
+        icon="pause"
         :title="t('p.task.pause')"
+        :aria-label="t('p.task.pause')"
         @click="emit('pause')"
-      >
-        <Icon name="pause" />
-      </button>
-      <button
+      />
+      <SimpleButton
         v-if="showStop"
-        class="plain-button"
-        data-ui="button"
-        data-variant="plain"
+        variant="plain"
+        icon="stop"
         :title="t('p.task.stop')"
+        :aria-label="t('p.task.stop')"
         @click="emit('stop')"
-      >
-        <Icon name="stop" />
-      </button>
-      <button
+      />
+      <SimpleButton
         v-if="showRemove"
-        class="plain-button"
-        data-ui="button"
-        data-variant="plain"
+        variant="plain"
+        icon="close"
         :title="t('p.task.remove')"
+        :aria-label="t('p.task.remove')"
         @click="emit('remove')"
-      >
-        <Icon name="close" />
-      </button>
+      />
     </span>
   </div>
 </template>
@@ -260,7 +252,7 @@ const showRemove = computed(() => !showStop.value)
   width: 60px;
   white-space: nowrap;
   text-align: right;
-  .plain-button {
+  .simple-button.plain {
     font-size: 18px;
   }
 }


### PR DESCRIPTION
## Summary

- add solid, outline, and plain SimpleButton variants
- reuse plain buttons across form, dialog, media, task, and navigation controls
- keep form add controls and dropdown triggers consistent

Refs #181

## Validation

- npm run lint
- npm run build-web