### PR TITLE
fix(onedrive): treat oauth as configured when drive listing fails

### DIFF
--- a/drive/onedrive/index.go
+++ b/drive/onedrive/index.go
@@ -89,17 +89,20 @@ func NewOneDrive(_ context.Context, config types.SM,
 
 	driveId := params["drive_id"]
 	sharePointId := params["share_point_id"]
-
-	if driveId == "" && sharePointId == "" {
-		return nil, err.NewNotAllowedMessageError(t("drive_not_selected"))
-	}
+	sharePointURL := config["share_point"]
 
 	site := getSiteConfig(config["site"])
 	var reqPrefix string
-	if driveId != "" {
-		reqPrefix = utils.BuildURL(site.ApiBase+"/drives/{}", driveId)
-	} else {
+	switch {
+	case sharePointURL != "":
+		if sharePointId == "" {
+			return nil, err.NewNotAllowedMessageError(t("drive_not_selected"))
+		}
 		reqPrefix = utils.BuildURL(site.ApiBase+"/sites/{}/drive", sharePointId)
+	case driveId != "":
+		reqPrefix = utils.BuildURL(site.ApiBase+"/drives/{}", driveId)
+	default:
+		reqPrefix = site.ApiBase + "/me/drive"
 	}
 
 	od.c, e = req.NewClient(reqPrefix, nil, ifApiCallError, resp.Client())

--- a/drive/onedrive/util.go
+++ b/drive/onedrive/util.go
@@ -141,19 +141,15 @@ func InitConfig(ctx context.Context, config types.SM,
 
 	sharePointURL := config["share_point"]
 
-	// get drives
+	// If listing drives succeeds, the user must pick one. /me/drives needs
+	// Files.ReadWrite.All; with only Files.ReadWrite it 403s. In that case skip
+	// the selector and use the user's default drive (/me/drive).
 	if initConfig.Configured && sharePointURL == "" {
-		_ = generateDrivesForm(ctx, reqClient, config, params, initConfig)
-	}
-
-	// if no SharePoint site provided, get the user's drives
-	// otherwise, treat the SharePoint site as a drive
-	if initConfig.Configured {
-		if sharePointURL == "" {
+		if e := generateDrivesForm(ctx, reqClient, config, params, initConfig); e == nil {
 			initConfig.Configured = params["drive_id"] != ""
-		} else {
-			initConfig.Configured = params["share_point_id"] != ""
 		}
+	} else if initConfig.Configured {
+		initConfig.Configured = params["share_point_id"] != ""
 	}
 
 	return initConfig, nil
@@ -205,10 +201,12 @@ func Init(ctx context.Context, data types.SM, config types.SM, utils driveutil.D
 func generateDrivesForm(ctx context.Context, reqClient *req.Client,
 	config types.SM, params types.SM, initConfig *driveutil.DriveInitConfig) error {
 	drives, e := getDrives(ctx, reqClient, config["site"])
-	initConfig.Configured = e == nil
 	if e != nil {
 		log.Println("[OneDrive] Error getting drives:", e)
 		return e
+	}
+	if len(drives) == 0 {
+		return errors.New("no drives")
 	}
 	opts := make([]types.FormItemOption, len(drives))
 	for i, d := range drives {


### PR DESCRIPTION
## Summary
- Skip the OneDrive drive selector when `GET /me/drives` fails (for example 403 without `Files.ReadWrite.All`) or returns no drives.
- Mark initialization as configured after a successful OAuth/user lookup in that case, and use `/me/drive` as the default personal drive.
- Keep requiring an explicit drive pick when listing succeeds, and still require a resolved SharePoint site id when a SharePoint URL is configured.

## Test plan
- [ ] Authorize a personal OneDrive app with only `Files.ReadWrite` (no `.All`); confirm init shows configured, no drive dropdown, and listing/upload works against the default drive.
- [ ] Authorize with `Files.ReadWrite.All` when multiple drives exist; confirm the selector still appears and configured stays false until a drive is chosen.
- [ ] Authorize a personal account that only has one drive with `.All`; confirm the selector appears with that single drive.
- [ ] Configure a SharePoint URL and confirm missing site id still reports not configured / `drive_not_selected`.


Made with [Cursor](https://cursor.com)