### PR TITLE
feat(script): hashing, unpadded base64, and http content-length

### DIFF
--- a/docs/scripts/global.d.ts
+++ b/docs/scripts/global.d.ts
@@ -218,13 +218,25 @@ declare interface HttpResponse {
 
 declare function newFormData(): HttpFormData;
 
-/** HTTP request. Dispose the response when finished. */
+declare interface HttpRequestOptions {
+  headers?: SM;
+  body?: HttpBody;
+}
+
+/**
+ * HTTP request. Dispose the response when finished.
+ *
+ * For a Reader `body`, `Content-Length` is taken from `headers` when present
+ * (the body is truncated to that size). Otherwise a known size is used
+ * (`TempFile` remaining bytes, including `ProgressReader` / `LimitReader`
+ * wrapping one). String and Bytes always use their actual length. FormData is
+ * multipart. Set `Transfer-Encoding: chunked` to skip auto `Content-Length`.
+ */
 declare function http(
   ctx: Context,
   method: HttpMethod,
   url: string,
-  headers?: SM,
-  body?: HttpBody
+  req?: HttpRequestOptions
 ): HttpResponse;
 
 declare type FormItemType =
@@ -347,19 +359,30 @@ declare enum HASH {
 
 declare interface Hasher {
   Write(b: Bytes): Hasher;
+  /**
+   * Hash `r` from the current offset to EOF. Does not close `r`.
+   * Does not seek to the start. To hash a whole TempFile, `SeekTo(0, SEEK_START)` first.
+   * If `r` is seekable (`TempFile`), the original offset is restored afterwards.
+   */
+  WriteReader(r: Reader): Hasher;
   Sum(): Bytes;
 }
 
-/** Hex / Base64 / HMAC helpers. */
+/** Hex / Base64 / HMAC / digest helpers. */
 declare const encUtils: {
   toHex: (b: Bytes) => string;
   fromHex: (s: string) => Bytes;
-  base64Encode: (b: Bytes) => string;
-  base64Decode: (s: string) => Bytes;
-  urlBase64Encode: (b: Bytes) => string;
-  urlBase64Decode: (s: string) => Bytes;
+  /** `padded` defaults to `true`. Pass `false` for raw (no `=`). */
+  base64Encode: (b: Bytes, padded?: boolean) => string;
+  base64Decode: (s: string, padded?: boolean) => Bytes;
+  /** URL-safe Base64. `padded` defaults to `true`; `false` for JWT / PKCE. */
+  urlBase64Encode: (b: Bytes, padded?: boolean) => string;
+  urlBase64Decode: (s: string, padded?: boolean) => Bytes;
+  /** Cryptographically random bytes. `n` must be in `[0, 1MiB]`. */
+  randomBytes: (n: number) => Bytes;
   newHash: (h: HASH) => Hasher;
-  hmac: (h: HASH, payload: Bytes, key: Bytes) => Bytes;
+  /** Streaming HMAC; `Write` / `WriteReader` / `Sum` like `newHash`. */
+  newHmac: (h: HASH, key: Bytes) => Hasher;
 };
 
 declare interface EntryTreeNode {

--- a/docs/site/jobs/index.md
+++ b/docs/site/jobs/index.md
@@ -96,8 +96,9 @@ cp('incoming/**/*.jpg', 'archive', true)
 var ctx = newContextWithTimeout(newContext(), ms(10000))
 try {
   var resp = http(ctx, 'POST', 'https://example.com/hook', {
-    'content-type': 'application/json'
-  }, JSON.stringify($event))
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify($event)
+  })
   try {
     log('webhook: ' + resp.Status)
   } finally {

--- a/docs/site/zh-CN/jobs/index.md
+++ b/docs/site/zh-CN/jobs/index.md
@@ -97,8 +97,9 @@ cp('incoming/**/*.jpg', 'archive', true)
 var ctx = newContextWithTimeout(newContext(), ms(10000))
 try {
   var resp = http(ctx, 'POST', 'https://example.com/hook', {
-    'content-type': 'application/json'
-  }, JSON.stringify($event))
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify($event)
+  })
   try {
     log('webhook: ' + resp.Status)
   } finally {

--- a/script-drives/AGENTS.md
+++ b/script-drives/AGENTS.md
@@ -303,8 +303,9 @@ Follow `dropbox.js`. Do not persist OAuth state manually or duplicate refresh-to
 
 ### HTTP
 
-- `http(ctx, method, url, headers?, body?) -> HttpResponse`; methods are HEAD, GET, POST, PUT, DELETE, PATCH, and OPTIONS.
+- `http(ctx, method, url, { headers, body }?) -> HttpResponse`; methods are HEAD, GET, POST, PUT, DELETE, PATCH, and OPTIONS.
 - The body may be a Reader, string, Bytes, or HttpFormData.
+- For a Reader body, `Content-Length` comes from `headers` when set (the body is truncated to that size). Otherwise a known size is used (`TempFile` remaining bytes, including `ProgressReader` / `LimitReader` wrapping one) so object-storage PUT is not chunked. String and Bytes always use their actual length. FormData is multipart. Set `Transfer-Encoding: chunked` to skip auto `Content-Length`.
 - `newFormData()`, with `AppendField` and `AppendFile`.
 - `HttpResponse.Status`, `Body`, `BodySize()`, `Text()`, and `Dispose()`.
 - `HttpResponse.Headers.Get(key)`, `Values(key)`, and `GetAll()`.
@@ -339,10 +340,12 @@ Log only inside a `DEBUG` branch, and redact arguments before constructing the l
 
 - `pathUtils.clean/join/parent/base/ext/isRoot`.
 - `dayjs` and `toDate(goTime)`; GoTime also has `UnixMilli()`.
-- `encUtils.toHex/fromHex/base64Encode/base64Decode/urlBase64Encode/urlBase64Decode`.
-- `encUtils.newHash(HASH.*)`; Hasher has `Write` and `Sum`.
-- `encUtils.hmac(HASH.*, payloadBytes, keyBytes)`.
-- HASH supports MD5, SHA1, SHA256, and SHA512.
+- `encUtils.toHex/fromHex`.
+- `encUtils.base64Encode/base64Decode` and `urlBase64Encode/urlBase64Decode`; second argument `padded` defaults to `true`. Pass `false` for raw encoding (JWT, PKCE).
+- `encUtils.randomBytes(n)` (CSPRNG; `n` in `[0, 1MiB]`).
+- `encUtils.newHash(HASH.*)`; Hasher has `Write`, `WriteReader`, and `Sum`.
+- `encUtils.newHmac(HASH.*, keyBytes)` returns a streaming Hasher.
+- HASH supports MD5, SHA1, SHA256, and SHA512. `WriteReader` hashes from the current offset to EOF (it does not seek to the start). On a seekable `TempFile` it restores that same offset, so hashing from the middle (`SeekTo` then `WriteReader`) and then continuing from that point works. After `Write`, call `SeekTo(0, SEEK_START)` if the whole file must be hashed or uploaded. One-shot Readers (response bodies) are consumed; copy them to a TempFile first if they must be reused. When a digest must appear in request headers (`Content-MD5`), hash the TempFile, then `http()`.
 
 ### Traversal helpers
 
@@ -433,16 +436,13 @@ defineDrive(
       ctx.Total(size, true);
       var route = "/v1/content?path=" + encodeURIComponent(path) +
         "&override=" + (override ? "true" : "false");
-      var resp = http(
-        ctx,
-        "PUT",
-        this.baseURL + route,
-        {
+      var resp = http(ctx, "PUT", this.baseURL + route, {
+        headers: {
           Authorization: "Bearer " + this.token,
           "Content-Type": "application/octet-stream"
         },
-        reader.ProgressReader(ctx)
-      );
+        body: reader.ProgressReader(ctx)
+      });
       var status = resp.Status;
       var message = resp.Text();
       if (status === 409) throw ErrNotAllowed("destination already exists");
@@ -493,7 +493,10 @@ function requestJSON(drive, ctx, method, route, body) {
     headers["Content-Type"] = "application/json";
     payload = JSON.stringify(body);
   }
-  var resp = http(ctx, method, drive.baseURL + route, headers, payload);
+  var resp = http(ctx, method, drive.baseURL + route, {
+    headers: headers,
+    body: payload
+  });
   var status = resp.Status;
   var text = resp.Text();
   var data = {};

--- a/script-drives/dropbox.js
+++ b/script-drives/dropbox.js
@@ -352,8 +352,7 @@ function request(oauthHolder, ctx, method, url, headers, body, contentApi) {
     (contentApi
       ? "https://content.dropboxapi.com/2"
       : "https://api.dropboxapi.com/2") + url,
-    headers,
-    body
+    { headers: headers, body: body }
   );
   var isJSON =
     r.Headers.Get("Content-Type").toLowerCase().indexOf("application/json") >=

--- a/script-drives/github.js
+++ b/script-drives/github.js
@@ -403,7 +403,7 @@ function request(drive, ctx, method, path) {
     headers.Authorization = "Bearer " + drive.token;
   }
   if (DEBUG) console.log("http", method, path);
-  return http(ctx, method, API_BASE + path, headers, null);
+  return http(ctx, method, API_BASE + path, { headers: headers });
 }
 
 /**

--- a/script-drives/qiniu.js
+++ b/script-drives/qiniu.js
@@ -1,5 +1,5 @@
 // @name Qiniu
-// @version 1.0.1
+// @version 1.0.2
 // @uploader qiniu-uploader.js
 // @description Qiniu Kodo
 
@@ -212,7 +212,7 @@ function saveSmall(drive, ctx, path, reader) {
   );
   data.AppendFile("file", pathUtils.base(path), reader);
 
-  var resp = http(ctx, "POST", drive.uploadURL, null, data);
+  var resp = http(ctx, "POST", drive.uploadURL, { body: data });
   var respData = resp.Text();
   try {
     respData = JSON.parse(respData);
@@ -234,7 +234,7 @@ function getDownloadURL(baseURL, key, ak, sk) {
     ak +
     ":" +
     encUtils.urlBase64Encode(
-      encUtils.hmac(HASH.SHA1, newBytes(url), newBytes(sk))
+      encUtils.newHmac(HASH.SHA1, newBytes(sk)).Write(newBytes(url)).Sum()
     );
 
   return url + "&token=" + encodeURIComponent(sign);
@@ -288,7 +288,7 @@ function request(drive, ctx, method, url, headers, body) {
   if (DEBUG) {
     console.log("[HTTP REQ]", method, url, JSON.stringify(headers), body);
   }
-  var r = http(ctx, method, url, headers, body);
+  var r = http(ctx, method, url, { headers: headers, body: body });
 
   var isJSON =
     r.Headers.Get("Content-Type").toLowerCase().indexOf("application/json") >=
@@ -330,7 +330,7 @@ function getUploadSignature(ak, sk, bucket, key, returnBody) {
   });
   var encodedPutPolicy = encUtils.urlBase64Encode(newBytes(putPolicy));
   var sign = encUtils.urlBase64Encode(
-    encUtils.hmac(HASH.SHA1, newBytes(encodedPutPolicy), newBytes(sk))
+    encUtils.newHmac(HASH.SHA1, newBytes(sk)).Write(newBytes(encodedPutPolicy)).Sum()
   );
   return ak + ":" + sign + ":" + encodedPutPolicy;
 }
@@ -370,7 +370,7 @@ function getManagementSignature(ak, sk, host, method, url, headers, bodyStr) {
     ak +
     ":" +
     encUtils.urlBase64Encode(
-      encUtils.hmac(HASH.SHA1, newBytes(payload), newBytes(sk))
+      encUtils.newHmac(HASH.SHA1, newBytes(sk)).Write(newBytes(payload)).Sum()
     );
   return s;
 }

--- a/script/call.go
+++ b/script/call.go
@@ -39,7 +39,8 @@ func initVarsForVm(v *VM) {
 	v.o.Set("__encURLBase64Decode__", WrapVmCall(v, vm_urlBase64Decode))
 
 	v.o.Set("__newHash__", WrapVmCall(v, vm_newHash))
-	v.o.Set("__hmac__", WrapVmCall(v, vm_hmac))
+	v.o.Set("__newHmac__", WrapVmCall(v, vm_newHmac))
+	v.o.Set("__randomBytes__", WrapVmCall(v, vm_randomBytes))
 
 	v.o.Set("buildEntriesTree", WrapVmCall(v, vm_buildEntriesTree))
 	v.o.Set("flattenEntriesTree", WrapVmCall(v, vm_flattenEntriesTree))

--- a/script/call_enc.go
+++ b/script/call_enc.go
@@ -3,6 +3,7 @@ package script
 import (
 	"crypto/hmac"
 	"crypto/md5"
+	"crypto/rand"
 	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/sha512"
@@ -10,42 +11,91 @@ import (
 	"encoding/hex"
 	"errors"
 	"hash"
+	"io"
 )
 
-// vm_base64Encode: (b Bytes) string
+func optionalBool(arg *Value, defaultVal bool) bool {
+	if arg.IsNil() {
+		return defaultVal
+	}
+	return arg.Bool()
+}
+
+func encodeBase64(b []byte, url, padded bool) string {
+	switch {
+	case url && padded:
+		return base64.URLEncoding.EncodeToString(b)
+	case url && !padded:
+		return base64.RawURLEncoding.EncodeToString(b)
+	case padded:
+		return base64.StdEncoding.EncodeToString(b)
+	default:
+		return base64.RawStdEncoding.EncodeToString(b)
+	}
+}
+
+func decodeBase64(vm *VM, s string, url, padded bool) Bytes {
+	var (
+		r   []byte
+		err error
+	)
+	switch {
+	case url && padded:
+		r, err = base64.URLEncoding.DecodeString(s)
+	case url && !padded:
+		r, err = base64.RawURLEncoding.DecodeString(s)
+	case padded:
+		r, err = base64.StdEncoding.DecodeString(s)
+	default:
+		r, err = base64.RawStdEncoding.DecodeString(s)
+	}
+	if err != nil {
+		vm.ThrowError(err)
+	}
+	return NewBytes(vm, r)
+}
+
+// vm_base64Encode: (b Bytes, padded bool = true) string
 func vm_base64Encode(vm *VM, args Values) any {
-	return base64.StdEncoding.EncodeToString(GetBytes(args.Get(0).Raw()))
+	return encodeBase64(GetBytes(args.Get(0).Raw()), false, optionalBool(args.Get(1), true))
 }
 
-// vm_base64Decode: (s string) Bytes
+// vm_base64Decode: (s string, padded bool = true) Bytes
 func vm_base64Decode(vm *VM, args Values) any {
-	r, e := base64.StdEncoding.DecodeString(args.Get(0).String())
-	if e != nil {
-		vm.ThrowError(e)
-	}
-	return NewBytes(vm, r)
+	return decodeBase64(vm, args.Get(0).String(), false, optionalBool(args.Get(1), true))
 }
 
-// vm_urlBase64Encode: (s Bytes) string
+// vm_urlBase64Encode: (s Bytes, padded bool = true) string
 func vm_urlBase64Encode(vm *VM, args Values) any {
-	return base64.URLEncoding.EncodeToString(GetBytes(args.Get(0).Raw()))
+	return encodeBase64(GetBytes(args.Get(0).Raw()), true, optionalBool(args.Get(1), true))
 }
 
-// vm_urlBase64Decode: (s string) Bytes
+// vm_urlBase64Decode: (s string, padded bool = true) Bytes
 func vm_urlBase64Decode(vm *VM, args Values) any {
-	r, e := base64.URLEncoding.DecodeString(args.Get(0).String())
-	if e != nil {
-		vm.ThrowError(e)
-	}
-	return NewBytes(vm, r)
+	return decodeBase64(vm, args.Get(0).String(), true, optionalBool(args.Get(1), true))
 }
 
-// vm_urlBase64Encode: (s Bytes) string
+const maxRandomBytes = 1 << 20
+
+// vm_randomBytes: (n int) Bytes
+func vm_randomBytes(vm *VM, args Values) any {
+	n := args.Get(0).Integer()
+	if n < 0 || n > maxRandomBytes {
+		vm.ThrowError(errors.New("randomBytes: size must be between 0 and 1MiB"))
+	}
+	b := make([]byte, n)
+	if n > 0 {
+		if _, e := rand.Read(b); e != nil {
+			vm.ThrowError(e)
+		}
+	}
+	return NewBytes(vm, b)
+}
+
 func vm_toHex(vm *VM, args Values) any {
 	return hex.EncodeToString(GetBytes(args.Get(0).Raw()))
 }
 
-// vm_urlBase64Decode: (s string) Bytes
 func vm_fromHex(vm *VM, args Values) any {
 	b, e := hex.DecodeString(args.Get(0).String())
 	if e != nil {
@@ -69,28 +119,55 @@ func hashFn(vm *VM, t int) func() hash.Hash {
 	return fn
 }
 
-type hasher struct {
+type Hasher struct {
 	vm *VM
 	s  hash.Hash
 }
 
-func (h hasher) Write(b Bytes) hasher {
+func (h Hasher) Write(b Bytes) Hasher {
 	_, _ = h.s.Write(b.b)
 	return h
 }
 
-func (h hasher) Sum() Bytes {
+// WriteReader hashes from the current offset to EOF. Seekable readers (TempFile)
+// are restored to that offset; they are not rewound to the start.
+func (h Hasher) WriteReader(r any) Hasher {
+	reader := GetReader(r)
+	if reader == nil {
+		h.vm.ThrowTypeError("WriteReader requires a Reader")
+	}
+	var (
+		seeker io.Seeker
+		pos    int64
+	)
+	if s, ok := reader.(io.Seeker); ok {
+		off, e := s.Seek(0, io.SeekCurrent)
+		if e != nil {
+			h.vm.ThrowError(e)
+		}
+		seeker, pos = s, off
+	}
+	if _, e := io.Copy(h.s, reader); e != nil {
+		h.vm.ThrowError(e)
+	}
+	if seeker != nil {
+		if _, e := seeker.Seek(pos, io.SeekStart); e != nil {
+			h.vm.ThrowError(e)
+		}
+	}
+	return h
+}
+
+func (h Hasher) Sum() Bytes {
 	r := h.s.Sum(nil)
 	return NewBytes(h.vm, r)
 }
 
 func vm_newHash(vm *VM, args Values) any {
-	return hasher{vm, hashFn(vm, int(args.Get(0).Integer()))()}
+	return Hasher{vm, hashFn(vm, int(args.Get(0).Integer()))()}
 }
 
-// vm_hmac: (typ int, payload, key Bytes) Bytes
-func vm_hmac(vm *VM, args Values) any {
-	mac := hmac.New(hashFn(vm, int(args.Get(0).Integer())), GetBytes(args.Get(2).Raw()))
-	_, _ = mac.Write(GetBytes(args.Get(1).Raw()))
-	return NewBytes(vm, mac.Sum(nil))
+func vm_newHmac(vm *VM, args Values) any {
+	mac := hmac.New(hashFn(vm, int(args.Get(0).Integer())), GetBytes(args.Get(1).Raw()))
+	return Hasher{vm, mac}
 }

--- a/script/call_enc_test.go
+++ b/script/call_enc_test.go
@@ -1,0 +1,138 @@
+package script
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/md5"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+func newScriptTestVM(t *testing.T) *VM {
+	t.Helper()
+	vm := newPoolTestVM(t).Fork()
+	t.Cleanup(func() { _ = vm.Dispose() })
+	return vm
+}
+
+func TestEncBase64Padding(t *testing.T) {
+	vm := newScriptTestVM(t)
+	padded := evalJSString(t, vm, `encUtils.urlBase64Encode(newBytes("hello"))`)
+	if padded != "aGVsbG8=" {
+		t.Fatalf("urlBase64Encode padded = %q, want aGVsbG8=", padded)
+	}
+	raw := evalJSString(t, vm, `encUtils.urlBase64Encode(newBytes("hello"), false)`)
+	if raw != "aGVsbG8" {
+		t.Fatalf("urlBase64Encode raw = %q, want aGVsbG8", raw)
+	}
+	decoded := evalJSString(t, vm, `encUtils.urlBase64Decode("aGVsbG8", false).String()`)
+	if decoded != "hello" {
+		t.Fatalf("urlBase64Decode raw = %q, want hello", decoded)
+	}
+	stdRaw := evalJSString(t, vm, `encUtils.base64Encode(newBytes("hello"), false)`)
+	if stdRaw != "aGVsbG8" {
+		t.Fatalf("base64Encode raw = %q, want aGVsbG8", stdRaw)
+	}
+	stdDecoded := evalJSString(t, vm, `encUtils.base64Decode("aGVsbG8", false).String()`)
+	if stdDecoded != "hello" {
+		t.Fatalf("base64Decode raw = %q, want hello", stdDecoded)
+	}
+}
+
+func TestEncRandomBytes(t *testing.T) {
+	vm := newScriptTestVM(t)
+	a := evalJSString(t, vm, `encUtils.toHex(encUtils.randomBytes(16))`)
+	b := evalJSString(t, vm, `encUtils.toHex(encUtils.randomBytes(16))`)
+	if len(a) != 32 || len(b) != 32 {
+		t.Fatalf("randomBytes hex length a=%d b=%d, want 32", len(a), len(b))
+	}
+	if a == b {
+		t.Fatal("randomBytes returned the same value twice")
+	}
+	empty := evalJSInt(t, vm, `encUtils.randomBytes(0).Len()`)
+	if empty != 0 {
+		t.Fatalf("randomBytes(0).Len() = %d, want 0", empty)
+	}
+	if _, e := vm.Run(context.Background(), `encUtils.randomBytes(-1)`); e == nil {
+		t.Fatal("expected error for negative size")
+	}
+}
+
+func TestEncWriteReaderRewindsTempFile(t *testing.T) {
+	vm := newScriptTestVM(t)
+	payload := "abc"
+	md5Sum := md5.Sum([]byte(payload))
+	mac := hmac.New(sha256.New, []byte("key"))
+	_, _ = mac.Write([]byte(payload))
+	wantHMAC := hex.EncodeToString(mac.Sum(nil))
+
+	got := evalJSString(t, vm, `
+(function() {
+  var tmp = newTempFile();
+  tmp.Write(newBytes("abc"));
+  tmp.SeekTo(0, SEEK_START);
+  var md5 = encUtils.toHex(encUtils.newHash(HASH.MD5).WriteReader(tmp).Sum());
+  var hmacHex = encUtils.toHex(
+    encUtils.newHmac(HASH.SHA256, newBytes("key")).WriteReader(tmp).Sum()
+  );
+  var oneShot = encUtils.toHex(
+    encUtils.newHmac(HASH.SHA256, newBytes("key")).Write(newBytes("abc")).Sum()
+  );
+  var again = tmp.ReadAsString();
+  tmp.Close();
+  if (hmacHex !== oneShot) throw new Error("hmac mismatch");
+  return md5 + " " + hmacHex + " " + again;
+})()
+`)
+	want := hex.EncodeToString(md5Sum[:]) + " " + wantHMAC + " abc"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestEncWriteReaderFromCurrentOffset(t *testing.T) {
+	vm := newScriptTestVM(t)
+	want := md5.Sum([]byte("cdefgh"))
+	got := evalJSString(t, vm, `
+(function() {
+  var tmp = newTempFile();
+  tmp.Write(newBytes("abcdefgh"));
+  tmp.SeekTo(2, SEEK_START);
+  var sum = encUtils.toHex(encUtils.newHash(HASH.MD5).WriteReader(tmp).Sum());
+  var rest = tmp.ReadAsString();
+  tmp.Close();
+  return sum + " " + rest;
+})()
+`)
+	if got != hex.EncodeToString(want[:])+" cdefgh" {
+		t.Fatalf("got %q, want hash of cdefgh then remainder cdefgh", got)
+	}
+}
+
+func evalJSString(t *testing.T, vm *VM, code string) string {
+	t.Helper()
+	v, e := vm.Run(context.Background(), code)
+	if e != nil {
+		t.Fatal(e)
+	}
+	return v.String()
+}
+
+func evalJSInt(t *testing.T, vm *VM, code string) int64 {
+	t.Helper()
+	v, e := vm.Run(context.Background(), code)
+	if e != nil {
+		t.Fatal(e)
+	}
+	return v.Integer()
+}
+
+func TestEncRandomBytesRejectsTooLarge(t *testing.T) {
+	vm := newScriptTestVM(t)
+	_, e := vm.Run(context.Background(), `encUtils.randomBytes(1048577)`)
+	if e == nil || !strings.Contains(e.Error(), "randomBytes") {
+		t.Fatalf("expected size error, got %v", e)
+	}
+}

--- a/script/call_http.go
+++ b/script/call_http.go
@@ -2,11 +2,15 @@ package script
 
 import (
 	"bytes"
+	"fmt"
 	gReq "go-drive/common/req"
+	"go-drive/common/types"
 	"go-drive/common/utils"
 	"io"
 	"mime/multipart"
 	"net/http"
+	"strconv"
+	"strings"
 )
 
 var httpClient, _ = gReq.NewClient("", nil, nil, nil)
@@ -28,13 +32,46 @@ func newHTTPRequestBody(r io.Reader, n int64, typ string) gReq.RequestBody {
 	return &httpRequestBody{r: r, n: n, typ: typ}
 }
 
-// vm_http: (ctx Context, method, url string, headers types.SM, body any) *httpResponse
+func headerValue(headers types.SM, name string) (string, bool) {
+	for k, v := range headers {
+		if strings.EqualFold(k, name) {
+			return v, true
+		}
+	}
+	return "", false
+}
+
+func readerBodyLength(headers types.SM, r io.Reader) (int64, error) {
+	if te, ok := headerValue(headers, "Transfer-Encoding"); ok && strings.Contains(strings.ToLower(te), "chunked") {
+		return -1, nil
+	}
+	if raw, ok := headerValue(headers, "Content-Length"); ok && raw != "" {
+		n, e := strconv.ParseInt(strings.TrimSpace(raw), 10, 64)
+		if e != nil || n < 0 {
+			return 0, fmt.Errorf("invalid Content-Length")
+		}
+		return n, nil
+	}
+	return readerKnownLength(r), nil
+}
+
+// vm_http: (ctx, method, url, { headers, body }?) *httpResponse
 func vm_http(vm *VM, args Values) any {
 	ctx := args.Get(0).Raw()
 	method := args.Get(1).String()
 	url := args.Get(2).String()
-	headers := args.Get(3).SM()
-	body := args.Get(4).Raw()
+	opt := args.Get(3)
+
+	var headers types.SM
+	var body any
+	if !opt.IsNil() {
+		if h := opt.Get("headers"); h != nil && !h.IsNil() {
+			headers = h.SM()
+		}
+		if b := opt.Get("body"); b != nil && !b.IsNil() {
+			body = b.Raw()
+		}
+	}
 
 	var reqBody gReq.RequestBody
 	var errChan chan error
@@ -44,7 +81,14 @@ func vm_http(vm *VM, args Values) any {
 			b := []byte(str)
 			reqBody = newHTTPRequestBody(bytes.NewReader(b), int64(len(b)), "")
 		} else if vr := GetReader(body); vr != nil {
-			reqBody = newHTTPRequestBody(vr, -1, "")
+			n, e := readerBodyLength(headers, vr)
+			if e != nil {
+				vm.ThrowError(e)
+			}
+			if n >= 0 {
+				vr = io.LimitReader(vr, n)
+			}
+			reqBody = newHTTPRequestBody(vr, n, "")
 		} else if b := GetBytes(body); b != nil {
 			reqBody = newHTTPRequestBody(bytes.NewReader(b), int64(len(b)), "")
 		} else if fd, ok := body.(*formData); ok {

--- a/script/call_http_test.go
+++ b/script/call_http_test.go
@@ -1,0 +1,185 @@
+package script
+
+import (
+	"context"
+	"crypto/md5"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+)
+
+type capturedRequest struct {
+	mu               sync.Mutex
+	contentLength    int64
+	transferEncoding []string
+	body             string
+}
+
+func (c *capturedRequest) handler(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.contentLength = r.ContentLength
+	c.transferEncoding = append([]string(nil), r.TransferEncoding...)
+	c.body = string(body)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func startCaptureServer(t *testing.T) (*httptest.Server, *capturedRequest) {
+	t.Helper()
+	cap := &capturedRequest{}
+	srv := httptest.NewServer(http.HandlerFunc(cap.handler))
+	t.Cleanup(srv.Close)
+	return srv, cap
+}
+
+func TestHTTPTempFileSetsContentLength(t *testing.T) {
+	srv, cap := startCaptureServer(t)
+	vm := newScriptTestVM(t)
+	vm.Set("url", srv.URL)
+	if _, e := vm.Run(context.Background(), `
+		var tmp = newTempFile();
+		tmp.Write(newBytes("hello"));
+		tmp.SeekTo(0, SEEK_START);
+		var resp = http(newContext(), "PUT", url, { body: tmp });
+		resp.Dispose();
+		tmp.Close();
+	`); e != nil {
+		t.Fatal(e)
+	}
+	if cap.contentLength != 5 {
+		t.Fatalf("ContentLength = %d, want 5", cap.contentLength)
+	}
+	if len(cap.transferEncoding) != 0 {
+		t.Fatalf("TransferEncoding = %v, want empty", cap.transferEncoding)
+	}
+	if cap.body != "hello" {
+		t.Fatalf("body = %q, want hello", cap.body)
+	}
+}
+
+func TestHTTPChunkedWhenTransferEncodingSet(t *testing.T) {
+	srv, cap := startCaptureServer(t)
+	vm := newScriptTestVM(t)
+	vm.Set("url", srv.URL)
+	if _, e := vm.Run(context.Background(), `
+		var tmp = newTempFile();
+		tmp.Write(newBytes("hello"));
+		tmp.SeekTo(0, SEEK_START);
+		var resp = http(newContext(), "PUT", url, {
+			headers: { "Transfer-Encoding": "chunked" },
+			body: tmp
+		});
+		resp.Dispose();
+		tmp.Close();
+	`); e != nil {
+		t.Fatal(e)
+	}
+	if cap.contentLength != -1 {
+		t.Fatalf("ContentLength = %d, want -1", cap.contentLength)
+	}
+	if cap.body != "hello" {
+		t.Fatalf("body = %q, want hello", cap.body)
+	}
+}
+
+func TestHTTPWriteReaderThenUploadTempFile(t *testing.T) {
+	srv, cap := startCaptureServer(t)
+	vm := newScriptTestVM(t)
+	vm.Set("url", srv.URL)
+	sum := evalJSString(t, vm, `
+(function() {
+  var tmp = newTempFile();
+  tmp.Write(newBytes("abc"));
+  tmp.SeekTo(0, SEEK_START);
+  var h = encUtils.newHash(HASH.MD5).WriteReader(tmp);
+  var resp = http(newContext(), "PUT", url, { body: tmp });
+  resp.Dispose();
+  tmp.Close();
+  return encUtils.toHex(h.Sum());
+})()
+`)
+	want := md5.Sum([]byte("abc"))
+	if sum != hex.EncodeToString(want[:]) {
+		t.Fatalf("MD5 = %q, want %q", sum, hex.EncodeToString(want[:]))
+	}
+	if cap.contentLength != 3 {
+		t.Fatalf("ContentLength = %d, want 3", cap.contentLength)
+	}
+	if cap.body != "abc" {
+		t.Fatalf("body = %q, want abc", cap.body)
+	}
+}
+
+func TestHTTPProgressReaderPreservesLength(t *testing.T) {
+	srv, cap := startCaptureServer(t)
+	vm := newScriptTestVM(t)
+	vm.Set("url", srv.URL)
+	if _, e := vm.Run(context.Background(), `
+		var tmp = newTempFile();
+		tmp.Write(newBytes("xyz"));
+		tmp.SeekTo(0, SEEK_START);
+		var ctx = newTaskCtx(newContext());
+		var resp = http(ctx, "PUT", url, { body: tmp.ProgressReader(ctx) });
+		resp.Dispose();
+		tmp.Close();
+	`); e != nil {
+		t.Fatal(e)
+	}
+	if cap.contentLength != 3 {
+		t.Fatalf("ContentLength = %d, want 3", cap.contentLength)
+	}
+	if cap.body != "xyz" {
+		t.Fatalf("body = %q, want xyz", cap.body)
+	}
+}
+
+func TestHTTPLimitReaderAutoLength(t *testing.T) {
+	srv, cap := startCaptureServer(t)
+	vm := newScriptTestVM(t)
+	vm.Set("url", srv.URL)
+	if _, e := vm.Run(context.Background(), `
+		var tmp = newTempFile();
+		tmp.Write(newBytes("hello"));
+		tmp.SeekTo(0, SEEK_START);
+		var resp = http(newContext(), "PUT", url, { body: tmp.LimitReader(2) });
+		resp.Dispose();
+		tmp.Close();
+	`); e != nil {
+		t.Fatal(e)
+	}
+	if cap.contentLength != 2 {
+		t.Fatalf("ContentLength = %d, want 2", cap.contentLength)
+	}
+	if cap.body != "he" {
+		t.Fatalf("body = %q, want he", cap.body)
+	}
+}
+
+func TestHTTPContentLengthHeader(t *testing.T) {
+	srv, cap := startCaptureServer(t)
+	vm := newScriptTestVM(t)
+	vm.Set("url", srv.URL)
+	if _, e := vm.Run(context.Background(), `
+		var tmp = newTempFile();
+		tmp.Write(newBytes("hello"));
+		tmp.SeekTo(0, SEEK_START);
+		var resp = http(newContext(), "PUT", url, {
+			headers: { "Content-Length": "2" },
+			body: tmp
+		});
+		resp.Dispose();
+		tmp.Close();
+	`); e != nil {
+		t.Fatal(e)
+	}
+	if cap.contentLength != 2 {
+		t.Fatalf("ContentLength = %d, want 2", cap.contentLength)
+	}
+	if cap.body != "he" {
+		t.Fatalf("body = %q, want he", cap.body)
+	}
+}

--- a/script/js/50.common.js
+++ b/script/js/50.common.js
@@ -184,8 +184,9 @@ var encUtils = Object.freeze({
   base64Decode: __encBase64Decode__,
   urlBase64Encode: __encURLBase64Encode__,
   urlBase64Decode: __encURLBase64Decode__,
+  randomBytes: __randomBytes__,
   newHash: __newHash__,
-  hmac: __hmac__,
+  newHmac: __newHmac__,
 });
 
 var SEEK_START = 0;

--- a/script/object_io.go
+++ b/script/object_io.go
@@ -133,11 +133,124 @@ func (r Reader) ReadAsString() string {
 }
 
 func (r Reader) LimitReader(n int64) Reader {
-	return NewReader(r.vm, io.LimitReader(r.r, n))
+	limited := io.LimitReader(r.r, n)
+	if f, ok := underlyingFile(r.r); ok {
+		return NewReader(r.vm, limitedFileReader{r: limited, f: f, limit: n})
+	}
+	if k := readerKnownLength(r.r); k >= 0 {
+		if k > n {
+			k = n
+		}
+		return NewReader(r.vm, fixedLengthReader{r: limited, n: k})
+	}
+	return NewReader(r.vm, limited)
 }
 
 func (r Reader) ProgressReader(ctx any) Reader {
-	return NewReader(r.vm, driveutil.ProgressReader(r.r, GetTaskCtx(ctx)))
+	return wrapPreservingLength(r.vm, driveutil.ProgressReader(r.r, GetTaskCtx(ctx)), r.r)
+}
+
+type contentLengthReader interface {
+	ContentLength() int64
+}
+
+type fixedLengthReader struct {
+	r io.Reader
+	n int64
+}
+
+func (f fixedLengthReader) Read(p []byte) (int, error) {
+	return f.r.Read(p)
+}
+
+func (f fixedLengthReader) ContentLength() int64 {
+	return f.n
+}
+
+type sizedFileReader struct {
+	r io.Reader
+	f *os.File
+}
+
+func (s sizedFileReader) Read(p []byte) (int, error) {
+	return s.r.Read(p)
+}
+
+func (s sizedFileReader) ContentLength() int64 {
+	return remainingFileSize(s.f)
+}
+
+type limitedFileReader struct {
+	r     io.Reader
+	f     *os.File
+	limit int64
+}
+
+func (l limitedFileReader) Read(p []byte) (int, error) {
+	return l.r.Read(p)
+}
+
+func (l limitedFileReader) ContentLength() int64 {
+	rem := remainingFileSize(l.f)
+	if rem < 0 {
+		return -1
+	}
+	if rem > l.limit {
+		return l.limit
+	}
+	return rem
+}
+
+func wrapPreservingLength(vm *VM, wrapped, orig io.Reader) Reader {
+	if f, ok := underlyingFile(orig); ok {
+		return NewReader(vm, sizedFileReader{r: wrapped, f: f})
+	}
+	if n := readerKnownLength(orig); n >= 0 {
+		return NewReader(vm, fixedLengthReader{r: wrapped, n: n})
+	}
+	return NewReader(vm, wrapped)
+}
+
+func underlyingFile(r io.Reader) (*os.File, bool) {
+	if f, ok := r.(*os.File); ok {
+		return f, true
+	}
+	if s, ok := r.(sizedFileReader); ok {
+		return s.f, true
+	}
+	if l, ok := r.(limitedFileReader); ok {
+		return l.f, true
+	}
+	return nil, false
+}
+
+func remainingFileSize(f *os.File) int64 {
+	off, e := f.Seek(0, io.SeekCurrent)
+	if e != nil {
+		return -1
+	}
+	info, e := f.Stat()
+	if e != nil {
+		return -1
+	}
+	n := info.Size() - off
+	if n < 0 {
+		return 0
+	}
+	return n
+}
+
+func readerKnownLength(r io.Reader) int64 {
+	if r == nil {
+		return -1
+	}
+	if cl, ok := r.(contentLengthReader); ok {
+		return cl.ContentLength()
+	}
+	if f, ok := r.(*os.File); ok {
+		return remainingFileSize(f)
+	}
+	return -1
 }
 
 type ReadCloser struct {


### PR DESCRIPTION
## Summary
- `http(ctx, method, url, { headers, body })` sets `Content-Length` from the header or from a known-size `TempFile` (including `ProgressReader` / `LimitReader` wrappers) so object-storage PUT is not forced to chunked encoding.
- `encUtils` gains `randomBytes`, streaming `newHmac` / `Hasher.WriteReader` (hash from the current offset; seekable readers restore that offset), and an optional `padded` flag on Base64 helpers for JWT/PKCE.
- Built-in script drives and job examples are updated to the new `http()` shape.

## Test plan
- [ ] `go test ./script ./drive/script`
- [ ] `go test -race ./script`
- [ ] Confirm a script PUT of a `TempFile` sends `Content-Length` (not chunked)
- [ ] Confirm `WriteReader` on a `TempFile` after `SeekTo(n)` hashes from `n` and leaves the offset at `n`
- [ ] Smoke Dropbox / Qiniu / GitHub script drives if convenient


Made with [Cursor](https://cursor.com)