### PR TITLE
refactor(script): 删除非流式 encUtils.hmac

### DIFF
--- a/docs/scripts/global.d.ts
+++ b/docs/scripts/global.d.ts
@@ -383,7 +383,6 @@ declare const encUtils: {
   newHash: (h: HASH) => Hasher;
   /** Streaming HMAC; `Write` / `WriteReader` / `Sum` like `newHash`. */
   newHmac: (h: HASH, key: Bytes) => Hasher;
-  hmac: (h: HASH, payload: Bytes, key: Bytes) => Bytes;
 };
 
 declare interface EntryTreeNode {

--- a/script-drives/AGENTS.md
+++ b/script-drives/AGENTS.md
@@ -345,7 +345,6 @@ Log only inside a `DEBUG` branch, and redact arguments before constructing the l
 - `encUtils.randomBytes(n)` (CSPRNG; `n` in `[0, 1MiB]`).
 - `encUtils.newHash(HASH.*)`; Hasher has `Write`, `WriteReader`, and `Sum`.
 - `encUtils.newHmac(HASH.*, keyBytes)` returns a streaming Hasher.
-- `encUtils.hmac(HASH.*, payloadBytes, keyBytes)`.
 - HASH supports MD5, SHA1, SHA256, and SHA512. `WriteReader` hashes from the current offset to EOF (it does not seek to the start). On a seekable `TempFile` it restores that same offset, so hashing from the middle (`SeekTo` then `WriteReader`) and then continuing from that point works. After `Write`, call `SeekTo(0, SEEK_START)` if the whole file must be hashed or uploaded. One-shot Readers (response bodies) are consumed; copy them to a TempFile first if they must be reused. When a digest must appear in request headers (`Content-MD5`), hash the TempFile, then `http()`.
 
 ### Traversal helpers

--- a/script-drives/qiniu.js
+++ b/script-drives/qiniu.js
@@ -1,5 +1,5 @@
 // @name Qiniu
-// @version 1.0.1
+// @version 1.0.2
 // @uploader qiniu-uploader.js
 // @description Qiniu Kodo
 
@@ -234,7 +234,7 @@ function getDownloadURL(baseURL, key, ak, sk) {
     ak +
     ":" +
     encUtils.urlBase64Encode(
-      encUtils.hmac(HASH.SHA1, newBytes(url), newBytes(sk))
+      encUtils.newHmac(HASH.SHA1, newBytes(sk)).Write(newBytes(url)).Sum()
     );
 
   return url + "&token=" + encodeURIComponent(sign);
@@ -330,7 +330,7 @@ function getUploadSignature(ak, sk, bucket, key, returnBody) {
   });
   var encodedPutPolicy = encUtils.urlBase64Encode(newBytes(putPolicy));
   var sign = encUtils.urlBase64Encode(
-    encUtils.hmac(HASH.SHA1, newBytes(encodedPutPolicy), newBytes(sk))
+    encUtils.newHmac(HASH.SHA1, newBytes(sk)).Write(newBytes(encodedPutPolicy)).Sum()
   );
   return ak + ":" + sign + ":" + encodedPutPolicy;
 }
@@ -370,7 +370,7 @@ function getManagementSignature(ak, sk, host, method, url, headers, bodyStr) {
     ak +
     ":" +
     encUtils.urlBase64Encode(
-      encUtils.hmac(HASH.SHA1, newBytes(payload), newBytes(sk))
+      encUtils.newHmac(HASH.SHA1, newBytes(sk)).Write(newBytes(payload)).Sum()
     );
   return s;
 }

--- a/script/call.go
+++ b/script/call.go
@@ -40,7 +40,6 @@ func initVarsForVm(v *VM) {
 
 	v.o.Set("__newHash__", WrapVmCall(v, vm_newHash))
 	v.o.Set("__newHmac__", WrapVmCall(v, vm_newHmac))
-	v.o.Set("__hmac__", WrapVmCall(v, vm_hmac))
 	v.o.Set("__randomBytes__", WrapVmCall(v, vm_randomBytes))
 
 	v.o.Set("buildEntriesTree", WrapVmCall(v, vm_buildEntriesTree))

--- a/script/call_enc.go
+++ b/script/call_enc.go
@@ -171,10 +171,3 @@ func vm_newHmac(vm *VM, args Values) any {
 	mac := hmac.New(hashFn(vm, int(args.Get(0).Integer())), GetBytes(args.Get(1).Raw()))
 	return Hasher{vm, mac}
 }
-
-// vm_hmac: (typ int, payload, key Bytes) Bytes
-func vm_hmac(vm *VM, args Values) any {
-	mac := hmac.New(hashFn(vm, int(args.Get(0).Integer())), GetBytes(args.Get(2).Raw()))
-	_, _ = mac.Write(GetBytes(args.Get(1).Raw()))
-	return NewBytes(vm, mac.Sum(nil))
-}

--- a/script/call_enc_test.go
+++ b/script/call_enc_test.go
@@ -77,7 +77,9 @@ func TestEncWriteReaderRewindsTempFile(t *testing.T) {
   var hmacHex = encUtils.toHex(
     encUtils.newHmac(HASH.SHA256, newBytes("key")).WriteReader(tmp).Sum()
   );
-  var oneShot = encUtils.toHex(encUtils.hmac(HASH.SHA256, newBytes("abc"), newBytes("key")));
+  var oneShot = encUtils.toHex(
+    encUtils.newHmac(HASH.SHA256, newBytes("key")).Write(newBytes("abc")).Sum()
+  );
   var again = tmp.ReadAsString();
   tmp.Close();
   if (hmacHex !== oneShot) throw new Error("hmac mismatch");

--- a/script/js/50.common.js
+++ b/script/js/50.common.js
@@ -187,7 +187,6 @@ var encUtils = Object.freeze({
   randomBytes: __randomBytes__,
   newHash: __newHash__,
   newHmac: __newHmac__,
-  hmac: __hmac__,
 });
 
 var SEEK_START = 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

`encUtils.newHmac` 已提供流式 Hasher（`Write` / `WriteReader` / `Sum`），一次性 `hmac()` 与其重复。本分支本身已有脚本 API 破坏性变更，因此直接删除该辅助方法。

## 变更

- 删除 `encUtils.hmac` / `vm_hmac` 及 JS 绑定。
- 七牛脚本签名改为 `encUtils.newHmac(...).Write(...).Sum()`，版本 `1.0.1` → `1.0.2`。
- 更新 `global.d.ts` 与 `script-drives/AGENTS.md`。
- 测试改为用 `newHmac().Write()` 对照 `WriteReader()`。

## 兼容性

脚本中原先调用 `encUtils.hmac(HASH, payload, key)` 的地方需改为：

```js
encUtils.newHmac(HASH, key).Write(payload).Sum()
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7e134141-9326-4e5e-99eb-a6b824481a12?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e134141-9326-4e5e-99eb-a6b824481a12&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

