### PR TITLE
fix(fs): block Windows path traversal via unsanitized backslashes

### DIFF
--- a/common/utils/permission_resolver_test.go
+++ b/common/utils/permission_resolver_test.go
@@ -164,6 +164,15 @@ func TestPermMap_ResolvePath(t *testing.T) {
 			wantRead:    false,
 			wantWrite:   false,
 		},
+		{
+			name: "backslash traversal does not inherit writable ancestor",
+			permissions: []types.PathPermission{
+				{Path: ptr("files/users/bob"), Subject: types.AnySubject, Permission: types.PermissionReadWrite, Policy: types.PolicyAccept},
+			},
+			path:      `files/users/bob/..\..\secret`,
+			wantRead:  false,
+			wantWrite: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/common/utils/utils.go
+++ b/common/utils/utils.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	path2 "path"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -40,8 +41,12 @@ var unsafePathCharsRegexp = regexp.MustCompile(`[\x00-\x1f\x7f-\x9f]+`)
 
 func CleanPath(path string) string {
 	path = unsafePathCharsRegexp.ReplaceAllLiteralString(strings.TrimSpace(path), "")
-	// Clean the path as if it were rooted. This prevents leading parent
-	// components (including a final "..") from surviving the cleanup.
+	path = strings.ReplaceAll(path, "\\", "/")
+	if runtime.GOOS == "windows" {
+		// Windows filenames cannot contain ':'. Removing it also turns volume
+		// paths like `C:/Windows` into a relative slash path.
+		path = strings.ReplaceAll(path, ":", "")
+	}
 	return strings.TrimPrefix(path2.Clean("/"+path), "/")
 }
 

--- a/common/utils/utils_test.go
+++ b/common/utils/utils_test.go
@@ -1,6 +1,9 @@
 package utils
 
 import (
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
@@ -46,6 +49,61 @@ func TestCleanPathRemovesParentTraversal(t *testing.T) {
 	}
 	if got := CleanPath("../../safe/file"); got != "safe/file" {
 		t.Errorf("CleanPath traversal result = %q", got)
+	}
+}
+
+func TestCleanPathNormalizesBackslashTraversal(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{input: `files\..\..\..\Windows\Temp\evil.txt`, want: `Windows/Temp/evil.txt`},
+		{input: `files/..\..\..\Windows\Temp\evil.txt`, want: `Windows/Temp/evil.txt`},
+		{input: `files/users/bob/..\..\..\Windows\Temp\x`, want: `Windows/Temp/x`},
+		{input: `files/users/bob/..\foo`, want: `files/users/foo`},
+		{input: `a\b\c`, want: `a/b/c`},
+		{input: `a/b\../c`, want: `a/c`},
+		{input: `..\..\Windows\Temp\victim.txt`, want: `Windows/Temp/victim.txt`},
+		{input: `C:\Windows\Temp\x`, want: windowsColonPath(`C:/Windows/Temp/x`)},
+		{input: `C:/Windows/Temp/x`, want: windowsColonPath(`C:/Windows/Temp/x`)},
+		{input: `files/C:\Windows\Temp\x`, want: windowsColonPath(`files/C:/Windows/Temp/x`)},
+		{input: `C:foo`, want: windowsColonPath(`C:foo`)},
+	}
+	for _, tt := range tests {
+		if got := CleanPath(tt.input); got != tt.want {
+			t.Errorf("CleanPath(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func windowsColonPath(slashPath string) string {
+	if runtime.GOOS == "windows" {
+		return strings.ReplaceAll(slashPath, ":", "")
+	}
+	return slashPath
+}
+
+func TestCleanPathResultCannotLexicallyEscape(t *testing.T) {
+	root := filepath.FromSlash("/drive/root")
+	inputs := []string{
+		`files/users/bob/..\..\..\Windows\Temp\evil.txt`,
+		`../outside/evil.txt`,
+		`C:\Windows\Temp\x`,
+		`files/C:\Windows\Temp\x`,
+		`..\..\..\..\Windows\Temp\victim.txt`,
+		``,
+		`a/b/c`,
+	}
+	for _, input := range inputs {
+		cleaned := CleanPath(input)
+		if strings.Contains(cleaned, `\`) {
+			t.Errorf("CleanPath(%q) still contains backslash: %q", input, cleaned)
+		}
+		resolved := filepath.Join(root, filepath.FromSlash(cleaned))
+		rel, e := filepath.Rel(root, resolved)
+		if e != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+			t.Errorf("CleanPath(%q)=%q joined to %q, escapes %q", input, cleaned, resolved, root)
+		}
 	}
 }
 

--- a/drive/chroot_test.go
+++ b/drive/chroot_test.go
@@ -1,0 +1,25 @@
+package drive
+
+import (
+	"testing"
+)
+
+func TestChrootWrapPathNormalizesBackslashTraversal(t *testing.T) {
+	c := NewChroot("files/users/bob", nil)
+
+	got, e := c.WrapPath(`..\..\secret`)
+	if e != nil {
+		t.Fatalf("WrapPath: %v", e)
+	}
+	if got != "files/users/bob/secret" {
+		t.Fatalf("WrapPath backslash traversal = %q, want jailed path", got)
+	}
+
+	got, e = c.WrapPath(`users/bob/..\..\..\Windows\Temp\x`)
+	if e != nil {
+		t.Fatalf("WrapPath mixed: %v", e)
+	}
+	if got != "files/users/bob/Windows/Temp/x" {
+		t.Fatalf("WrapPath mixed = %q", got)
+	}
+}

--- a/drive/dispatcher_test.go
+++ b/drive/dispatcher_test.go
@@ -1672,3 +1672,46 @@ func TestMount_Move_PhantomDirectoryMaterializesDestination(t *testing.T) {
 		t.Errorf("moved child mount does not resolve: %v", e)
 	}
 }
+
+func TestDispatcher_FsBackslashTraversalStaysInsideDrive(t *testing.T) {
+	d, _, config, cleanup := newTestDispatcher(t, []string{"driveA"})
+	defer cleanup()
+	ctx := context.Background()
+
+	localRoot, e := config.GetDir("local", false)
+	if e != nil {
+		t.Fatal(e)
+	}
+	outside := filepath.Join(filepath.Dir(localRoot), "outside")
+	if e := os.MkdirAll(outside, 0755); e != nil {
+		t.Fatal(e)
+	}
+	victim := filepath.Join(outside, "victim.txt")
+	if e := os.WriteFile(victim, []byte("keep"), 0644); e != nil {
+		t.Fatal(e)
+	}
+	if _, e := d.lower.MakeDir(ctx, "driveA/users"); e != nil {
+		t.Fatalf("MakeDir users: %v", e)
+	}
+	if _, e := d.lower.MakeDir(ctx, "driveA/users/bob"); e != nil {
+		t.Fatalf("MakeDir bob: %v", e)
+	}
+
+	payload := `driveA/users/bob/..\..\..\..\outside\evil.txt`
+	_, _ = d.lower.Save(task.DummyContext(), payload, 4, true, bytes.NewReader([]byte("evil")))
+	got, e := os.ReadFile(victim)
+	if e != nil {
+		t.Fatal(e)
+	}
+	if string(got) != "keep" {
+		t.Fatalf("outside victim mutated: %q", got)
+	}
+	if _, e := os.Stat(filepath.Join(outside, "evil.txt")); e == nil {
+		t.Fatal("backslash traversal wrote a file outside the fs drive root")
+	}
+	_ = d.lower.Delete(task.DummyContext(), `driveA/users/bob/..\..\..\..\outside\victim.txt`)
+	if _, e := os.Stat(victim); e != nil {
+		t.Fatalf("backslash traversal deleted the outside victim: %v", e)
+	}
+}
+

--- a/drive/fs/index.go
+++ b/drive/fs/index.go
@@ -103,8 +103,8 @@ func (f *Drive) newFsFile(path string, file os.FileInfo) (types.IEntry, error) {
 }
 
 func (f *Drive) getPath(path string) string {
-	path = filepath.Clean(path)
-	return filepath.Join(f.path, path)
+	path = utils.CleanPath(path)
+	return filepath.Join(f.path, filepath.FromSlash(path))
 }
 
 func (f *Drive) isRootPath(path string) bool {

--- a/drive/fs/index_test.go
+++ b/drive/fs/index_test.go
@@ -1,0 +1,169 @@
+package fs
+
+import (
+	"bytes"
+	"context"
+	err "go-drive/common/errors"
+	"go-drive/common/task"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newTestDrive(t *testing.T) (d *Drive, root, outside string) {
+	t.Helper()
+	base := t.TempDir()
+	root = filepath.Join(base, "root")
+	outside = filepath.Join(base, "outside")
+	if e := os.MkdirAll(root, 0755); e != nil {
+		t.Fatal(e)
+	}
+	if e := os.MkdirAll(outside, 0755); e != nil {
+		t.Fatal(e)
+	}
+	abs, e := filepath.Abs(root)
+	if e != nil {
+		t.Fatal(e)
+	}
+	return &Drive{path: abs}, abs, outside
+}
+
+func TestFsDriveBasicRoundTrip(t *testing.T) {
+	d, _, _ := newTestDrive(t)
+	ctx := context.Background()
+	taskCtx := task.DummyContext()
+
+	dir, e := d.MakeDir(ctx, "users")
+	if e != nil {
+		t.Fatalf("MakeDir users: %v", e)
+	}
+	if dir.Path() != "users" || !dir.Type().IsDir() {
+		t.Fatalf("MakeDir users entry = path %q type %v", dir.Path(), dir.Type())
+	}
+
+	saved, e := d.Save(taskCtx, "users/hello.txt", 5, true, bytes.NewReader([]byte("hello")))
+	if e != nil {
+		t.Fatalf("Save: %v", e)
+	}
+	if saved.Path() != "users/hello.txt" {
+		t.Fatalf("Save path = %q", saved.Path())
+	}
+
+	got, e := d.Get(ctx, "users/hello.txt")
+	if e != nil {
+		t.Fatalf("Get: %v", e)
+	}
+	reader, e := got.GetReader(ctx, -1, -1)
+	if e != nil {
+		t.Fatalf("GetReader: %v", e)
+	}
+	body, e := io.ReadAll(reader)
+	_ = reader.Close()
+	if e != nil {
+		t.Fatal(e)
+	}
+	if string(body) != "hello" {
+		t.Fatalf("content = %q", body)
+	}
+
+	entries, e := d.List(ctx, "users")
+	if e != nil {
+		t.Fatalf("List: %v", e)
+	}
+	if len(entries) != 1 || entries[0].Path() != "users/hello.txt" {
+		t.Fatalf("List = %v", entries)
+	}
+
+	moved, e := d.Move(taskCtx, got, "users/moved.txt", false)
+	if e != nil {
+		t.Fatalf("Move: %v", e)
+	}
+	if moved.Path() != "users/moved.txt" {
+		t.Fatalf("Move path = %q", moved.Path())
+	}
+
+	if e := d.Delete(taskCtx, "users/moved.txt"); e != nil {
+		t.Fatalf("Delete: %v", e)
+	}
+	if _, e := d.Get(ctx, "users/moved.txt"); e == nil || !err.IsNotFoundError(e) {
+		t.Fatalf("Get after delete: %v", e)
+	}
+}
+
+func TestFsDriveCleanPathKeepsWritesInsideRoot(t *testing.T) {
+	d, root, outside := newTestDrive(t)
+	ctx := context.Background()
+	taskCtx := task.DummyContext()
+
+	outsideFile := filepath.Join(outside, "victim.txt")
+	if e := os.WriteFile(outsideFile, []byte("keep"), 0644); e != nil {
+		t.Fatal(e)
+	}
+	if _, e := d.MakeDir(ctx, "users"); e != nil {
+		t.Fatalf("MakeDir users: %v", e)
+	}
+	if _, e := d.MakeDir(ctx, "users/bob"); e != nil {
+		t.Fatalf("MakeDir bob: %v", e)
+	}
+
+	payloads := []string{
+		`../outside/evil.txt`,
+		`..\\outside\\evil.txt`,
+		`users/bob/..\\..\\..\\outside\\evil.txt`,
+		`users/bob/../../../outside/evil.txt`,
+		`C:\Windows\Temp\evil.txt`,
+	}
+
+	for _, path := range payloads {
+		resolved := d.getPath(path)
+		if !isInsideRoot(root, resolved) {
+			t.Fatalf("getPath(%q) = %q, want inside %q", path, resolved, root)
+		}
+
+		_, _ = d.Save(taskCtx, path, 4, true, bytes.NewReader([]byte("evil")))
+		if !fileStillContains(outsideFile, "keep") {
+			t.Fatalf("Save(%q) mutated outside file", path)
+		}
+		if _, e := os.Stat(filepath.Join(outside, "evil.txt")); e == nil {
+			t.Fatalf("Save(%q) created outside file", path)
+		}
+
+		_ = d.Delete(taskCtx, path)
+		if !fileStillContains(outsideFile, "keep") {
+			t.Fatalf("Delete(%q) removed or mutated the outside victim", path)
+		}
+	}
+
+	entries, e := os.ReadDir(outside)
+	if e != nil {
+		t.Fatal(e)
+	}
+	if len(entries) != 1 || entries[0].Name() != "victim.txt" {
+		t.Fatalf("outside dir changed: %v", names(entries))
+	}
+}
+
+func isInsideRoot(root, target string) bool {
+	root = filepath.Clean(root)
+	target = filepath.Clean(target)
+	rel, e := filepath.Rel(root, target)
+	if e != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel)
+}
+
+func fileStillContains(path, want string) bool {
+	got, e := os.ReadFile(path)
+	return e == nil && string(got) == want
+}
+
+func names(entries []os.DirEntry) []string {
+	out := make([]string, len(entries))
+	for i, entry := range entries {
+		out[i] = entry.Name()
+	}
+	return out
+}

--- a/server/api_routes_test.go
+++ b/server/api_routes_test.go
@@ -269,6 +269,18 @@ func TestGetQueryPathRequiresParameterAndAllowsRoot(t *testing.T) {
 			t.Fatalf("getQueryPath() = %q, want %q", path, "a/c")
 		}
 	})
+
+	t.Run("backslash traversal", func(t *testing.T) {
+		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		c.Request = httptest.NewRequest(http.MethodGet, "/stat?path=files/users/bob/..%5C..%5C..%5CWindows%5CTemp%5Cx", nil)
+		path, e := getQueryPath(c, "path")
+		if e != nil {
+			t.Fatalf("getQueryPath() error = %v", e)
+		}
+		if path != "Windows/Temp/x" {
+			t.Fatalf("getQueryPath() = %q, want %q", path, "Windows/Temp/x")
+		}
+	})
 }
 
 func assertRegisteredRoutes(t *testing.T, router *gin.Engine, expected ...string) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On Windows, the local `fs` drive treated `\` as an ordinary filename character in the shared path model, then resolved it as a real path separator at the disk layer. An authenticated user with write permission on any single folder of an fs-backed drive could write, overwrite, mkdir, or delete files outside the configured drive root, bypassing both the per-path ACL and the chroot jail.

The fix is in `CleanPath`. Virtual paths are slash-based, so the stdlib lexical cleaner is `path.Clean`. Separators are normalized to `/`, Windows colons are removed (invalid in Windows filenames, which also turns `C:/Windows` into a relative path), then the path is cleaned as rooted and only the leading `/` is stripped.

## Changes

- `CleanPath`: `\` → `/`; on Windows drop `:`; then `strings.TrimPrefix(path.Clean("/"+path), "/")`.
- Dispatcher, ACL matching, and chroot therefore see the real path instead of one opaque backslash segment.
- `fs.getPath` uses `CleanPath` instead of OS-aware `filepath.Clean`.

Unix filenames that contain `:` are unchanged. Linux/macOS were not exploitable via `filepath` backslash traversal.

## Tests

- `CleanPath` backslash cases and Windows colon/volume cases
- ACL, HTTP `getQueryPath`, chroot, and fs drive Save/Delete stay inside the jail

`go test ./common/utils/ ./drive/fs/ ./drive/ ./server/` passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a75e94a-d6cb-466f-a92e-b81bfdd8302d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a75e94a-d6cb-466f-a92e-b81bfdd8302d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

